### PR TITLE
Add GPT-4o chatbot web app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+.env

--- a/README.md
+++ b/README.md
@@ -60,15 +60,23 @@ export OPENAI_API_KEY="your-openai-key"
       ]
     }
     ```
-  - **response**
-    ```json
-    {
-      "reply": "模型產生的回答",
-      "used_search": true,
-      "search_results": [
-        {"title": "結果標題", "snippet": "摘要", "url": "https://..."}
-      ]
-    }
+  - **response**：以 [Server-Sent Events](https://developer.mozilla.org/docs/Web/API/Server-sent_events) 形式串流傳回，事件類型說明如下：
+    - `meta`：包含 `used_search` 與 `search_results`，前端據此渲染查詢來源。
+    - `delta`：逐步輸出 `text` 欄位，為模型即時生成的片段。
+    - `done`：回傳最終完整的 `text` 內容。
+    - `error`：若產生錯誤則附上 `message` 描述。
+    
+    範例：
+
+    ```text
+    event: meta
+    data: {"used_search": true, "search_results": [{"title": "結果標題", "snippet": "摘要", "url": "https://..."}]}
+
+    event: delta
+    data: {"text": "第一段回覆"}
+
+    event: done
+    data: {"text": "完整回答"}
     ```
 
 ## 注意事項

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # GPT-4o Chatbot 網頁
 
-此專案提供一個使用 FastAPI 建立的後端與 HTML/JavaScript 前端的聊天機器人示例。後端透過 GPT-4o API 回答問題，並支援兩種使用模式：
+此專案提供一個使用 FastAPI 建立的後端與 HTML/JavaScript 前端的聊天機器人示例。後端透過 GPT-4o API 回答問題，並支援三種使用模式：
 
 1. **純 LLM 模式**：直接以模型的既有知識回覆。
-2. **網頁查詢 + LLM 模式**：先以 DuckDuckGo（透過 `duckduckgo-search` 套件）取得即時網頁摘要，再交由 GPT-4o 產生結合查詢資訊的回答。
+2. **網頁查詢（DuckDuckGo） + LLM 模式**：透過 `duckduckgo-search` 取得即時網頁摘要，再交由 GPT-4o 產生結合查詢資訊的回答。
+3. **網頁查詢（SerpAPI） + LLM 模式**：利用 SerpAPI 的 Google Search 結果，讓 GPT-4o 擷取與引用最新的網頁內容。
 
 ## 專案結構
 
@@ -27,6 +28,14 @@ export OPENAI_API_KEY="your-openai-key"
 ```
 
 > 若未設定金鑰，後端將回報 `OPENAI_API_KEY is not configured on the server.` 錯誤。
+
+- （選用）SerpAPI 金鑰，若要啟用 SerpAPI 模式需設定：
+
+```bash
+export SERPAPI_API_KEY="your-serpapi-key"
+```
+
+> 若未設定金鑰，選擇 SerpAPI 模式時後端將返回錯誤提示。
 
 ## 安裝與啟動
 
@@ -53,7 +62,7 @@ export OPENAI_API_KEY="your-openai-key"
     ```json
     {
       "message": "使用者訊息",
-      "mode": "llm_only" | "search",
+      "mode": "llm_only" | "search_duckduckgo" | "search_serpapi",
       "history": [
         {"role": "user", "content": "前一輪的提問"},
         {"role": "assistant", "content": "前一輪的回答"}
@@ -61,7 +70,7 @@ export OPENAI_API_KEY="your-openai-key"
     }
     ```
   - **response**：以 [Server-Sent Events](https://developer.mozilla.org/docs/Web/API/Server-sent_events) 形式串流傳回，事件類型說明如下：
-    - `meta`：包含 `used_search` 與 `search_results`，前端據此渲染查詢來源。
+      - `meta`：包含 `used_search`、`search_provider` 與 `search_results`，前端據此渲染查詢來源。
     - `delta`：逐步輸出 `text` 欄位，為模型即時生成的片段。
     - `done`：回傳最終完整的 `text` 內容。
     - `error`：若產生錯誤則附上 `message` 描述。
@@ -70,7 +79,7 @@ export OPENAI_API_KEY="your-openai-key"
 
     ```text
     event: meta
-    data: {"used_search": true, "search_results": [{"title": "結果標題", "snippet": "摘要", "url": "https://..."}]}
+    data: {"used_search": true, "search_provider": "duckduckgo", "search_results": [{"title": "結果標題", "snippet": "摘要", "url": "https://..."}]}
 
     event: delta
     data: {"text": "第一段回覆"}
@@ -82,9 +91,10 @@ export OPENAI_API_KEY="your-openai-key"
 ## 注意事項
 
 - DuckDuckGo 搜尋由 `duckduckgo-search` 套件驅動，會先以台灣地區（`tw-tzh`）查詢，若無結果再以全球設定重試。若網路連線失敗，後端仍會嘗試以 LLM 回覆。
+- SerpAPI 搜尋使用 `google-search-results` 套件，需提供有效的 SerpAPI API 金鑰，回傳的 `search_provider` 會標示為 `serpapi`。
 - 前端預設顯示繁體中文 UI，GPT-4o 會自動依照上下文在中英雙語間轉換。
 
 ## 開發建議
 
-- 若要擴充更多資料來源，可在 `app/main.py` 中的 `_perform_search` 函式新增其他查詢策略。
+- 若要擴充更多資料來源，可在 `app/main.py` 中新增對應的查詢函式並在 `/chat` 端點分支處理模式。
 - 可將前端改寫為框架式應用（例如 React/Vue）並透過 FastAPI 的 static mount 部署。此範例以簡潔的原生 HTML/JS 示範核心流程。

--- a/README.md
+++ b/README.md
@@ -1,0 +1,82 @@
+# GPT-4o Chatbot 網頁
+
+此專案提供一個使用 FastAPI 建立的後端與 HTML/JavaScript 前端的聊天機器人示例。後端透過 GPT-4o API 回答問題，並支援兩種使用模式：
+
+1. **純 LLM 模式**：直接以模型的既有知識回覆。
+2. **網頁查詢 + LLM 模式**：先以 DuckDuckGo 取得即時網頁摘要，再交由 GPT-4o 產生結合查詢資訊的回答。
+
+## 專案結構
+
+```
+.
+├── app
+│   └── main.py          # FastAPI 服務
+├── frontend
+│   └── index.html       # 前端單頁應用程式
+├── requirements.txt     # 相依套件
+└── README.md            # 操作說明
+```
+
+## 前置需求
+
+- Python 3.10+
+- OpenAI API 金鑰，並設定環境變數：
+
+```bash
+export OPENAI_API_KEY="your-openai-key"
+```
+
+> 若未設定金鑰，後端將回報 `OPENAI_API_KEY is not configured on the server.` 錯誤。
+
+## 安裝與啟動
+
+1. 安裝套件：
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. 啟動 FastAPI 伺服器（預設在 `http://127.0.0.1:8000`）：
+
+   ```bash
+   uvicorn app.main:app --reload
+   ```
+
+3. 在瀏覽器開啟 `http://127.0.0.1:8000/` 使用聊天介面。
+
+4. FastAPI 內建 Swagger 文件可在 `http://127.0.0.1:8000/docs` 查看與測試 API。
+
+## API 端點
+
+- `POST /chat`
+  - **body**
+    ```json
+    {
+      "message": "使用者訊息",
+      "mode": "llm_only" | "search",
+      "history": [
+        {"role": "user", "content": "前一輪的提問"},
+        {"role": "assistant", "content": "前一輪的回答"}
+      ]
+    }
+    ```
+  - **response**
+    ```json
+    {
+      "reply": "模型產生的回答",
+      "used_search": true,
+      "search_results": [
+        {"title": "結果標題", "snippet": "摘要", "url": "https://..."}
+      ]
+    }
+    ```
+
+## 注意事項
+
+- DuckDuckGo API 為公開服務，回傳內容可能依地域與查詢不同。若網路連線失敗，後端仍會嘗試以 LLM 回覆。
+- 前端預設顯示繁體中文 UI，GPT-4o 會自動依照上下文在中英雙語間轉換。
+
+## 開發建議
+
+- 若要擴充更多資料來源，可在 `app/main.py` 中的 `_perform_search` 函式新增其他查詢策略。
+- 可將前端改寫為框架式應用（例如 React/Vue）並透過 FastAPI 的 static mount 部署。此範例以簡潔的原生 HTML/JS 示範核心流程。

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 此專案提供一個使用 FastAPI 建立的後端與 HTML/JavaScript 前端的聊天機器人示例。後端透過 GPT-4o API 回答問題，並支援四種使用模式：
 
 1. **純 LLM 模式**：直接以模型的既有知識回覆。
-2. **網頁查詢（DuckDuckGo） + LLM 模式**：透過 `duckduckgo-search` 取得即時網頁摘要，再交由 GPT-4o 產生結合查詢資訊的回答。
+2. **網頁查詢（DuckDuckGo） + LLM 模式**：透過 `ddgs` 套件取得即時網頁摘要，再交由 GPT-4o 產生結合查詢資訊的回答。
 3. **網頁查詢（SerpAPI） + LLM 模式**：利用 SerpAPI 的 Google Search 結果，讓 GPT-4o 擷取與引用最新的網頁內容。
 4. **網頁查詢（自動判斷） + LLM 模式**：系統根據提問是否具有時效性或即時資訊需求決定是否啟動搜尋；若需要則呼叫 SerpAPI 擷取最新資料，否則僅以 LLM 回覆。
 
@@ -64,6 +64,7 @@ export SERPAPI_API_KEY="your-serpapi-key"
     {
       "message": "使用者訊息",
       "mode": "llm_only" | "search_duckduckgo" | "search_serpapi" | "search_auto",
+      "documents": ["上傳檔案的 ID"],
       "history": [
         {"role": "user", "content": "前一輪的提問"},
         {"role": "assistant", "content": "前一輪的回答"}
@@ -71,11 +72,11 @@ export SERPAPI_API_KEY="your-serpapi-key"
     }
     ```
   - **response**：以 [Server-Sent Events](https://developer.mozilla.org/docs/Web/API/Server-sent_events) 形式串流傳回，事件類型說明如下：
-      - `meta`：包含 `mode`、`used_search`、`search_provider` 與 `search_results` 等欄位；若為自動模式還會回傳 `auto_search_triggered` 表示是否實際執行 SerpAPI 搜尋。
+      - `meta`：包含 `mode`、`used_search`、`search_provider` 與 `search_results` 等欄位；若為自動模式還會回傳 `auto_search_triggered` 表示是否實際執行 SerpAPI 搜尋，並在 `documents` 欄位列出本次回答引用的上傳檔案。
     - `delta`：逐步輸出 `text` 欄位，為模型即時生成的片段。
     - `done`：回傳最終完整的 `text` 內容。
     - `error`：若產生錯誤則附上 `message` 描述。
-    
+
     範例：
 
     ```text
@@ -89,11 +90,23 @@ export SERPAPI_API_KEY="your-serpapi-key"
     data: {"text": "完整回答"}
     ```
 
+- `POST /upload`
+  - **body**：`multipart/form-data`，欄位名稱為 `file`，支援 PDF、純文字（`*.txt`、`*.md`、`*.csv` 等）檔案。
+  - **response**：回傳 `document_id`、`filename` 與 `char_count`，供後續 `/chat` 請求在 `documents` 欄位引用。
+
+## 上傳檔案使用方式
+
+1. 於前端頁面下方的「上傳參考檔案」區塊選擇 PDF 或純文字檔，上傳成功後會出現在清單中。
+2. 清單中的檔案會在每次提問時一併送往後端，後端會將文字內容整理為提示提供給 GPT-4o。
+3. 若不希望引用特定檔案，可直接點選清單中的「移除」按鈕。
+4. 回覆結束後，助理訊息會列出實際參考到的檔案，方便追蹤來源。
+
 ## 注意事項
 
-- DuckDuckGo 搜尋由 `duckduckgo-search` 套件驅動，會先以台灣地區（`tw-tzh`）查詢，若無結果再以全球設定重試。若網路連線失敗，後端仍會嘗試以 LLM 回覆。
+- DuckDuckGo 搜尋由 `ddgs` 套件驅動，會先以台灣地區（`tw-tzh`）查詢，若無結果再以全球設定重試。若網路連線失敗，後端仍會嘗試以 LLM 回覆。
 - SerpAPI 搜尋使用 `google-search-results` 套件，需提供有效的 SerpAPI API 金鑰，回傳的 `search_provider` 會標示為 `serpapi`。在「網頁查詢（自動判斷）」模式下，系統會根據關鍵字與語意判斷是否需要啟動即時搜尋，若啟用則同樣以 SerpAPI 提供內容。
 - 前端預設顯示繁體中文 UI，GPT-4o 會自動依照上下文在中英雙語間轉換。
+- 上傳的檔案內容僅暫存在伺服器記憶體中並以隨機 ID 辨識，伺服器重新啟動後需重新上傳。
 
 ## 開發建議
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # GPT-4o Chatbot 網頁
 
-此專案提供一個使用 FastAPI 建立的後端與 HTML/JavaScript 前端的聊天機器人示例。後端透過 GPT-4o API 回答問題，並支援三種使用模式：
+此專案提供一個使用 FastAPI 建立的後端與 HTML/JavaScript 前端的聊天機器人示例。後端透過 GPT-4o API 回答問題，並支援四種使用模式：
 
 1. **純 LLM 模式**：直接以模型的既有知識回覆。
 2. **網頁查詢（DuckDuckGo） + LLM 模式**：透過 `duckduckgo-search` 取得即時網頁摘要，再交由 GPT-4o 產生結合查詢資訊的回答。
 3. **網頁查詢（SerpAPI） + LLM 模式**：利用 SerpAPI 的 Google Search 結果，讓 GPT-4o 擷取與引用最新的網頁內容。
+4. **網頁查詢（自動判斷） + LLM 模式**：系統根據提問是否具有時效性或即時資訊需求決定是否啟動搜尋；若需要則呼叫 SerpAPI 擷取最新資料，否則僅以 LLM 回覆。
 
 ## 專案結構
 
@@ -62,7 +63,7 @@ export SERPAPI_API_KEY="your-serpapi-key"
     ```json
     {
       "message": "使用者訊息",
-      "mode": "llm_only" | "search_duckduckgo" | "search_serpapi",
+      "mode": "llm_only" | "search_duckduckgo" | "search_serpapi" | "search_auto",
       "history": [
         {"role": "user", "content": "前一輪的提問"},
         {"role": "assistant", "content": "前一輪的回答"}
@@ -70,7 +71,7 @@ export SERPAPI_API_KEY="your-serpapi-key"
     }
     ```
   - **response**：以 [Server-Sent Events](https://developer.mozilla.org/docs/Web/API/Server-sent_events) 形式串流傳回，事件類型說明如下：
-      - `meta`：包含 `used_search`、`search_provider` 與 `search_results`，前端據此渲染查詢來源。
+      - `meta`：包含 `mode`、`used_search`、`search_provider` 與 `search_results` 等欄位；若為自動模式還會回傳 `auto_search_triggered` 表示是否實際執行 SerpAPI 搜尋。
     - `delta`：逐步輸出 `text` 欄位，為模型即時生成的片段。
     - `done`：回傳最終完整的 `text` 內容。
     - `error`：若產生錯誤則附上 `message` 描述。
@@ -79,7 +80,7 @@ export SERPAPI_API_KEY="your-serpapi-key"
 
     ```text
     event: meta
-    data: {"used_search": true, "search_provider": "duckduckgo", "search_results": [{"title": "結果標題", "snippet": "摘要", "url": "https://..."}]}
+    data: {"mode": "search_duckduckgo", "used_search": true, "search_provider": "duckduckgo", "search_results": [{"title": "結果標題", "snippet": "摘要", "url": "https://..."}]}
 
     event: delta
     data: {"text": "第一段回覆"}
@@ -91,7 +92,7 @@ export SERPAPI_API_KEY="your-serpapi-key"
 ## 注意事項
 
 - DuckDuckGo 搜尋由 `duckduckgo-search` 套件驅動，會先以台灣地區（`tw-tzh`）查詢，若無結果再以全球設定重試。若網路連線失敗，後端仍會嘗試以 LLM 回覆。
-- SerpAPI 搜尋使用 `google-search-results` 套件，需提供有效的 SerpAPI API 金鑰，回傳的 `search_provider` 會標示為 `serpapi`。
+- SerpAPI 搜尋使用 `google-search-results` 套件，需提供有效的 SerpAPI API 金鑰，回傳的 `search_provider` 會標示為 `serpapi`。在「網頁查詢（自動判斷）」模式下，系統會根據關鍵字與語意判斷是否需要啟動即時搜尋，若啟用則同樣以 SerpAPI 提供內容。
 - 前端預設顯示繁體中文 UI，GPT-4o 會自動依照上下文在中英雙語間轉換。
 
 ## 開發建議

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 此專案提供一個使用 FastAPI 建立的後端與 HTML/JavaScript 前端的聊天機器人示例。後端透過 GPT-4o API 回答問題，並支援兩種使用模式：
 
 1. **純 LLM 模式**：直接以模型的既有知識回覆。
-2. **網頁查詢 + LLM 模式**：先以 DuckDuckGo 取得即時網頁摘要，再交由 GPT-4o 產生結合查詢資訊的回答。
+2. **網頁查詢 + LLM 模式**：先以 DuckDuckGo（透過 `duckduckgo-search` 套件）取得即時網頁摘要，再交由 GPT-4o 產生結合查詢資訊的回答。
 
 ## 專案結構
 
@@ -73,7 +73,7 @@ export OPENAI_API_KEY="your-openai-key"
 
 ## 注意事項
 
-- DuckDuckGo API 為公開服務，回傳內容可能依地域與查詢不同。若網路連線失敗，後端仍會嘗試以 LLM 回覆。
+- DuckDuckGo 搜尋由 `duckduckgo-search` 套件驅動，會先以台灣地區（`tw-tzh`）查詢，若無結果再以全球設定重試。若網路連線失敗，後端仍會嘗試以 LLM 回覆。
 - 前端預設顯示繁體中文 UI，GPT-4o 會自動依照上下文在中英雙語間轉換。
 
 ## 開發建議

--- a/app/main.py
+++ b/app/main.py
@@ -78,10 +78,16 @@ class ChatRequest(BaseModel):
     """Incoming chat payload from the front-end."""
 
     message: str = Field(..., description="The end-user prompt.")
-    mode: Literal["llm_only", "search_duckduckgo", "search_serpapi"] = Field(
+    mode: Literal[
+        "llm_only",
+        "search_duckduckgo",
+        "search_serpapi",
+        "search_auto",
+    ] = Field(
         "llm_only",
         description=(
-            "Choose between pure LLM, DuckDuckGo search-assisted, or SerpAPI search-assisted modes."
+            "Choose between pure LLM, DuckDuckGo search-assisted, SerpAPI search-assisted, "
+            "or automatic SerpAPI-assisted modes."
         ),
     )
     history: List[ChatMessage] = Field(
@@ -105,6 +111,51 @@ async def index() -> FileResponse:
 
 _ddgs_client = DDGS(timeout=10)
 _ddgs_lock = Lock()
+
+_AUTO_SEARCH_KEYWORDS_ZH = {
+    "最新",
+    "近期",
+    "最近",
+    "現在",
+    "目前",
+    "今日",
+    "今天",
+    "本日",
+    "本週",
+    "這週",
+    "下週",
+    "活動",
+    "新聞",
+    "快訊",
+    "更新",
+    "價格",
+    "票價",
+    "開放時間",
+    "時間表",
+    "行程",
+    "直播",
+    "賽況",
+}
+
+_AUTO_SEARCH_KEYWORDS_EN = {
+    "today",
+    "tonight",
+    "latest",
+    "recent",
+    "update",
+    "updates",
+    "news",
+    "event",
+    "events",
+    "schedule",
+    "release date",
+    "price",
+    "prices",
+    "opening hours",
+    "ticket",
+    "tickets",
+    "breaking",
+}
 
 
 def _perform_duckduckgo_search(query: str, max_results: int = 3) -> List[SearchResult]:
@@ -189,6 +240,31 @@ def _perform_serpapi_search(query: str, max_results: int = 3) -> List[SearchResu
             break
 
     return results
+
+
+def _should_use_auto_search(query: str) -> bool:
+    """Heuristically determine if the prompt needs fresh web context."""
+
+    query = query.strip()
+    if not query:
+        return False
+
+    lowered = query.lower()
+    if any(keyword in lowered for keyword in _AUTO_SEARCH_KEYWORDS_EN):
+        return True
+
+    # Normalize common punctuation before checking Traditional Chinese keywords.
+    normalized = query.replace("？", "?").replace("！", "!")
+    if any(keyword in normalized for keyword in _AUTO_SEARCH_KEYWORDS_ZH):
+        return True
+
+    # Prefer search for questions explicitly asking for time-sensitive info.
+    if "?" in normalized or "？" in query:
+        time_words = ("什麼時候", "何時", "多久", "在哪裡", "在哪裡可以", "哪裡買")
+        if any(word in normalized for word in time_words):
+            return True
+
+    return False
 
 
 def _build_messages(request: ChatRequest, search_results: Iterable[SearchResult]) -> List[dict]:
@@ -283,12 +359,18 @@ async def chat(request: ChatRequest) -> StreamingResponse:
 
     search_results: List[SearchResult] = []
     search_provider: Optional[str] = None
+    auto_search_triggered = False
     if request.mode == "search_duckduckgo":
         search_provider = "duckduckgo"
         search_results = _perform_duckduckgo_search(request.message)
     elif request.mode == "search_serpapi":
         search_provider = "serpapi"
         search_results = _perform_serpapi_search(request.message)
+    elif request.mode == "search_auto":
+        if _should_use_auto_search(request.message):
+            search_provider = "serpapi"
+            auto_search_triggered = True
+            search_results = _perform_serpapi_search(request.message)
 
     messages = _build_messages(request, search_results)
 
@@ -297,6 +379,8 @@ async def chat(request: ChatRequest) -> StreamingResponse:
             "used_search": bool(search_provider),
             "search_provider": search_provider,
             "search_results": [result.model_dump() for result in search_results],
+            "mode": request.mode,
+            "auto_search_triggered": auto_search_triggered,
         }
         yield _format_sse_event("meta", metadata)
         try:

--- a/app/main.py
+++ b/app/main.py
@@ -15,6 +15,7 @@ from fastapi.responses import FileResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from openai import OpenAI
 from pydantic import BaseModel, Field, validator
+from serpapi import GoogleSearch
 
 logger = logging.getLogger(__name__)
 
@@ -44,12 +45,18 @@ SYSTEM_PROMPT = (
 )
 
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+SERPAPI_API_KEY = os.getenv("SERPAPI_API_KEY")
 client: Optional[OpenAI]
 if OPENAI_API_KEY:
     client = OpenAI(api_key=OPENAI_API_KEY)
 else:
     client = None
     logger.warning("OPENAI_API_KEY not found. LLM requests will fail until it is set.")
+
+if not SERPAPI_API_KEY:
+    logger.info(
+        "SERPAPI_API_KEY not configured. SerpAPI search mode will be unavailable until set."
+    )
 
 
 class SearchResult(BaseModel):
@@ -71,8 +78,11 @@ class ChatRequest(BaseModel):
     """Incoming chat payload from the front-end."""
 
     message: str = Field(..., description="The end-user prompt.")
-    mode: Literal["llm_only", "search"] = Field(
-        "llm_only", description="Choose between pure LLM or search-assisted mode."
+    mode: Literal["llm_only", "search_duckduckgo", "search_serpapi"] = Field(
+        "llm_only",
+        description=(
+            "Choose between pure LLM, DuckDuckGo search-assisted, or SerpAPI search-assisted modes."
+        ),
     )
     history: List[ChatMessage] = Field(
         default_factory=list,
@@ -97,7 +107,7 @@ _ddgs_client = DDGS(timeout=10)
 _ddgs_lock = Lock()
 
 
-def _perform_search(query: str, max_results: int = 3) -> List[SearchResult]:
+def _perform_duckduckgo_search(query: str, max_results: int = 3) -> List[SearchResult]:
     """Query DuckDuckGo for lightweight search snippets."""
 
     query = query.strip()
@@ -134,8 +144,51 @@ def _perform_search(query: str, max_results: int = 3) -> List[SearchResult]:
             results = _fetch("wt-wt")
         return results
     except Exception as exc:  # pragma: no cover - network failure path
-        logger.warning("Search request failed: %s", exc)
+        logger.warning("DuckDuckGo search request failed: %s", exc)
         return []
+
+
+def _perform_serpapi_search(query: str, max_results: int = 3) -> List[SearchResult]:
+    """Query SerpAPI Google Search for rich snippets."""
+
+    query = query.strip()
+    if not query:
+        return []
+
+    if not SERPAPI_API_KEY:
+        raise HTTPException(
+            status_code=400,
+            detail="SERPAPI_API_KEY is not configured on the server.",
+        )
+
+    params = {
+        "engine": "google",
+        "q": query,
+        "hl": "zh-TW",
+        "gl": "tw",
+        "num": max_results,
+        "api_key": SERPAPI_API_KEY,
+    }
+
+    try:
+        response = GoogleSearch(params).get_dict()
+    except Exception as exc:  # pragma: no cover - network failure path
+        logger.warning("SerpAPI search request failed: %s", exc)
+        return []
+
+    organic_results = response.get("organic_results") or []
+    results: List[SearchResult] = []
+    for item in organic_results:
+        url = (item.get("link") or "").strip()
+        if not url:
+            continue
+        title = (item.get("title") or item.get("snippet") or url).strip()
+        snippet = (item.get("snippet") or item.get("title") or "").strip()
+        results.append(SearchResult(title=title, snippet=snippet, url=url))
+        if len(results) >= max_results:
+            break
+
+    return results
 
 
 def _build_messages(request: ChatRequest, search_results: Iterable[SearchResult]) -> List[dict]:
@@ -229,14 +282,20 @@ async def chat(request: ChatRequest) -> StreamingResponse:
         )
 
     search_results: List[SearchResult] = []
-    if request.mode == "search":
-        search_results = _perform_search(request.message)
+    search_provider: Optional[str] = None
+    if request.mode == "search_duckduckgo":
+        search_provider = "duckduckgo"
+        search_results = _perform_duckduckgo_search(request.message)
+    elif request.mode == "search_serpapi":
+        search_provider = "serpapi"
+        search_results = _perform_serpapi_search(request.message)
 
     messages = _build_messages(request, search_results)
 
     def _event_stream() -> Iterator[str]:
         metadata = {
-            "used_search": bool(search_results),
+            "used_search": bool(search_provider),
+            "search_provider": search_provider,
             "search_results": [result.model_dump() for result in search_results],
         }
         yield _format_sse_event("meta", metadata)

--- a/app/main.py
+++ b/app/main.py
@@ -178,7 +178,16 @@ def _run_llm(messages: List[dict]) -> str:
             detail="OPENAI_API_KEY is not configured on the server.",
         )
     try:
-        response = client.responses.create(model="gpt-4o", messages=messages)
+        response = client.responses.create(
+            model="gpt-4o",
+            input=[
+                {
+                    "role": message["role"],
+                    "content": message["content"],
+                }
+                for message in messages
+            ],
+        )
     except Exception as exc:  # pragma: no cover - network failure path
         logger.exception("LLM request failed")
         raise HTTPException(status_code=502, detail=f"LLM request failed: {exc}") from exc

--- a/app/main.py
+++ b/app/main.py
@@ -1,15 +1,17 @@
 """FastAPI backend for GPT-4o powered chatbot."""
 from __future__ import annotations
 
+import json
 import logging
 import os
 from pathlib import Path
-from typing import Iterable, List, Literal, Optional
+from threading import Lock
+from typing import Iterable, Iterator, List, Literal, Optional
 
 from duckduckgo_search import DDGS
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from openai import OpenAI
 from pydantic import BaseModel, Field, validator
@@ -82,16 +84,6 @@ class ChatRequest(BaseModel):
         if not msg.content:
             raise ValueError("History messages cannot be empty.")
         return msg
-
-
-class ChatResponse(BaseModel):
-    """Response returned to the front-end."""
-
-    reply: str
-    used_search: bool
-    search_results: List[SearchResult] = Field(default_factory=list)
-
-
 @app.get("/", include_in_schema=False)
 async def index() -> FileResponse:
     """Serve the single-page front-end application."""
@@ -99,6 +91,10 @@ async def index() -> FileResponse:
     if not index_file.exists():
         raise HTTPException(status_code=404, detail="Front-end not found.")
     return FileResponse(index_file)
+
+
+_ddgs_client = DDGS(timeout=10)
+_ddgs_lock = Lock()
 
 
 def _perform_search(query: str, max_results: int = 3) -> List[SearchResult]:
@@ -109,26 +105,28 @@ def _perform_search(query: str, max_results: int = 3) -> List[SearchResult]:
         return []
 
     def _fetch(region: str) -> List[SearchResult]:
-        with DDGS(timeout=10) as ddgs:
-            hits = ddgs.text(
-                query,
-                region=region,
-                safesearch="moderate",
-                max_results=max_results,
-            )
-            results: List[SearchResult] = []
-            for item in hits:
-                url = item.get("href", "").strip()
-                if not url:
-                    continue
-                title = item.get("title") or item.get("body") or url
-                snippet = item.get("body", "")
-                results.append(
-                    SearchResult(title=title.strip(), snippet=snippet.strip(), url=url)
+        with _ddgs_lock:
+            hits = list(
+                _ddgs_client.text(
+                    query,
+                    region=region,
+                    safesearch="moderate",
+                    max_results=max_results,
                 )
-                if len(results) >= max_results:
-                    break
-            return results
+            )
+        results: List[SearchResult] = []
+        for item in hits:
+            url = item.get("href", "").strip()
+            if not url:
+                continue
+            title = item.get("title") or item.get("body") or url
+            snippet = item.get("body", "")
+            results.append(
+                SearchResult(title=title.strip(), snippet=snippet.strip(), url=url)
+            )
+            if len(results) >= max_results:
+                break
+        return results
 
     try:
         results = _fetch("tw-tzh")
@@ -144,7 +142,7 @@ def _build_messages(request: ChatRequest, search_results: Iterable[SearchResult]
     """Compose the message array sent to GPT-4o."""
 
     messages: List[dict] = [{"role": "system", "content": SYSTEM_PROMPT}]
-    messages.extend(message.dict() for message in request.history)
+    messages.extend(message.model_dump() for message in request.history)
     context_lines = []
     for result in search_results:
         context_lines.append(f"Title: {result.title}\nURL: {result.url}\nSnippet: {result.snippet}")
@@ -164,16 +162,20 @@ def _build_messages(request: ChatRequest, search_results: Iterable[SearchResult]
     return messages
 
 
-def _run_llm(messages: List[dict]) -> str:
-    """Send messages to GPT-4o and extract the assistant reply."""
+def _stream_llm(messages: List[dict]) -> Iterator[tuple[str, dict]]:
+    """Stream chunks from GPT-4o and yield structured events."""
 
     if client is None:
         raise HTTPException(
             status_code=500,
             detail="OPENAI_API_KEY is not configured on the server.",
         )
+
+    collected_parts: List[str] = []
+    final_response = None
+
     try:
-        response = client.responses.create(
+        with client.responses.stream(
             model="gpt-4o",
             input=[
                 {
@@ -182,36 +184,86 @@ def _run_llm(messages: List[dict]) -> str:
                 }
                 for message in messages
             ],
-        )
+        ) as stream:
+            for event in stream:
+                if event.type == "response.output_text.delta":
+                    text = event.delta or ""
+                    if text:
+                        collected_parts.append(text)
+                        yield "delta", {"text": text}
+                elif event.type == "response.refusal.delta":
+                    text = event.delta or ""
+                    if text:
+                        collected_parts.append(text)
+                        yield "delta", {"text": text}
+            final_response = stream.get_final_response()
     except Exception as exc:  # pragma: no cover - network failure path
         logger.exception("LLM request failed")
         raise HTTPException(status_code=502, detail=f"LLM request failed: {exc}") from exc
 
-    if hasattr(response, "output_text") and response.output_text:
-        return response.output_text
+    full_text = "".join(collected_parts)
+    if not full_text and final_response is not None:
+        if hasattr(final_response, "output_text") and final_response.output_text:
+            full_text = final_response.output_text
+        else:
+            for item in getattr(final_response, "output", []):
+                if item.get("type") == "message":
+                    for content in item.get("content", []):
+                        if content.get("type") == "output_text":
+                            full_text += content.get("text", "")
 
-    collected_parts: List[str] = []
-    for item in getattr(response, "output", []):
-        if item.get("type") == "message":
-            for content in item.get("content", []):
-                if content.get("type") == "output_text":
-                    collected_parts.append(content.get("text", ""))
-    if not collected_parts:
+    if not full_text:
         raise HTTPException(status_code=502, detail="LLM returned an empty response.")
-    return "".join(collected_parts)
+
+    yield "done", {"text": full_text}
 
 
-@app.post("/chat", response_model=ChatResponse)
-async def chat(request: ChatRequest) -> ChatResponse:
-    """Primary chat endpoint used by the front-end."""
+@app.post("/chat")
+async def chat(request: ChatRequest) -> StreamingResponse:
+    """Primary chat endpoint used by the front-end with streaming replies."""
+
+    if client is None:
+        raise HTTPException(
+            status_code=500,
+            detail="OPENAI_API_KEY is not configured on the server.",
+        )
 
     search_results: List[SearchResult] = []
     if request.mode == "search":
         search_results = _perform_search(request.message)
 
     messages = _build_messages(request, search_results)
-    reply = _run_llm(messages)
-    return ChatResponse(reply=reply, used_search=bool(search_results), search_results=search_results)
+
+    def _event_stream() -> Iterator[str]:
+        metadata = {
+            "used_search": bool(search_results),
+            "search_results": [result.model_dump() for result in search_results],
+        }
+        yield _format_sse_event("meta", metadata)
+        try:
+            for event_type, payload in _stream_llm(messages):
+                yield _format_sse_event(event_type, payload)
+        except HTTPException as exc:
+            logger.exception("Streaming failed with HTTP error")
+            yield _format_sse_event("error", {"message": exc.detail})
+            return
+        except Exception as exc:  # pragma: no cover - network failure path
+            logger.exception("Streaming failed")
+            yield _format_sse_event("error", {"message": str(exc)})
+            return
+
+    return StreamingResponse(
+        _event_stream(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache"},
+    )
+
+
+def _format_sse_event(event_type: str, payload: dict) -> str:
+    """Encode an SSE event as a string."""
+
+    data = json.dumps(payload, ensure_ascii=False)
+    return f"event: {event_type}\ndata: {data}\n\n"
 
 
 __all__ = ["app"]

--- a/app/main.py
+++ b/app/main.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from threading import Lock
 from typing import Iterable, Iterator, List, Literal, Optional
 
-from duckduckgo_search import DDGS
+from ddgs import DDGS
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, StreamingResponse

--- a/app/main.py
+++ b/app/main.py
@@ -1,21 +1,24 @@
 """FastAPI backend for GPT-4o powered chatbot."""
 from __future__ import annotations
 
+import io
 import json
 import logging
 import os
 from pathlib import Path
 from threading import Lock
-from typing import Iterable, Iterator, List, Literal, Optional
+from typing import Dict, Iterable, Iterator, List, Literal, Optional
+from uuid import uuid4
 
 from ddgs import DDGS
-from fastapi import FastAPI, HTTPException
+from fastapi import File, FastAPI, HTTPException, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from openai import OpenAI
 from pydantic import BaseModel, Field, validator
 from serpapi import GoogleSearch
+from pypdf import PdfReader
 
 logger = logging.getLogger(__name__)
 
@@ -94,6 +97,10 @@ class ChatRequest(BaseModel):
         default_factory=list,
         description="Conversation history to maintain context across turns.",
     )
+    documents: List[str] = Field(
+        default_factory=list,
+        description="Identifiers for uploaded documents to reference in the reply.",
+    )
 
     @validator("history", each_item=True)
     def _strip_empty_history(cls, msg: ChatMessage) -> ChatMessage:
@@ -109,8 +116,32 @@ async def index() -> FileResponse:
     return FileResponse(index_file)
 
 
+@app.post("/upload")
+async def upload_document(file: UploadFile = File(...)) -> dict:
+    """Accept a reference document upload and store it for later chat turns."""
+
+    filename = file.filename or "uploaded_document"
+    try:
+        raw_bytes = await file.read()
+        content = _extract_text_from_upload(filename, file.content_type, raw_bytes)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    record = _store_document(filename, content)
+    return {
+        "document_id": record["document_id"],
+        "filename": record["filename"],
+        "char_count": len(content),
+    }
+
+
 _ddgs_client = DDGS(timeout=10)
 _ddgs_lock = Lock()
+
+_documents_lock = Lock()
+_uploaded_documents: Dict[str, Dict[str, str]] = {}
+
+_MAX_DOCUMENT_CHARS = 12_000
 
 _AUTO_SEARCH_KEYWORDS_ZH = {
     "最新",
@@ -156,6 +187,83 @@ _AUTO_SEARCH_KEYWORDS_EN = {
     "tickets",
     "breaking",
 }
+
+
+def _normalize_document_text(text: str) -> str:
+    """Trim and limit uploaded document text for prompt injection."""
+
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    normalized = "\n".join(lines)
+    if len(normalized) > _MAX_DOCUMENT_CHARS:
+        normalized = normalized[:_MAX_DOCUMENT_CHARS]
+    return normalized
+
+
+def _extract_text_from_upload(filename: str, content_type: Optional[str], data: bytes) -> str:
+    """Extract textual content from an uploaded file."""
+
+    if not data:
+        raise ValueError("檔案為空，無法取得內容。")
+
+    suffix = Path(filename or "").suffix.lower()
+    if (suffix == ".pdf") or (content_type == "application/pdf"):
+        try:
+            reader = PdfReader(io.BytesIO(data))
+        except Exception as exc:  # pragma: no cover - malformed PDF path
+            raise ValueError(f"PDF 解析失敗：{exc}") from exc
+        extracted_parts: List[str] = []
+        for page in reader.pages:
+            text = page.extract_text() or ""
+            if text:
+                extracted_parts.append(text)
+        extracted = "\n".join(extracted_parts)
+    elif (content_type and content_type.startswith("text/")) or suffix in {
+        ".txt",
+        ".md",
+        ".markdown",
+        ".csv",
+    }:
+        try:
+            extracted = data.decode("utf-8")
+        except UnicodeDecodeError:
+            extracted = data.decode("utf-8", errors="ignore")
+    else:
+        try:
+            extracted = data.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise ValueError("此檔案格式不支援，請提供 PDF 或純文字檔。") from exc
+
+    normalized = _normalize_document_text(extracted)
+    if not normalized:
+        raise ValueError("檔案內容為空，請確認檔案是否含有文字。")
+    return normalized
+
+
+def _store_document(filename: str, content: str) -> dict:
+    """Persist the uploaded document in memory and return metadata."""
+
+    document_id = uuid4().hex
+    with _documents_lock:
+        _uploaded_documents[document_id] = {"filename": filename, "content": content}
+    return {"document_id": document_id, "filename": filename}
+
+
+def _resolve_documents(document_ids: Iterable[str]) -> List[dict]:
+    """Fetch stored documents referenced in a chat request."""
+
+    resolved: List[dict] = []
+    missing: List[str] = []
+    with _documents_lock:
+        for document_id in document_ids:
+            record = _uploaded_documents.get(document_id)
+            if record:
+                resolved.append({"id": document_id, **record})
+            else:
+                missing.append(document_id)
+
+    if missing:
+        raise HTTPException(status_code=404, detail=f"找不到以下文件：{', '.join(missing)}")
+    return resolved
 
 
 def _perform_duckduckgo_search(query: str, max_results: int = 3) -> List[SearchResult]:
@@ -267,11 +375,37 @@ def _should_use_auto_search(query: str) -> bool:
     return False
 
 
-def _build_messages(request: ChatRequest, search_results: Iterable[SearchResult]) -> List[dict]:
+def _build_messages(
+    request: ChatRequest,
+    search_results: Iterable[SearchResult],
+    documents: Iterable[dict],
+) -> List[dict]:
     """Compose the message array sent to GPT-4o."""
 
     messages: List[dict] = [{"role": "system", "content": SYSTEM_PROMPT}]
     messages.extend(message.model_dump() for message in request.history)
+    document_lines: List[str] = []
+    for document in documents:
+        document_lines.append(
+            "\n".join(
+                [
+                    f"Filename: {document['filename']}",
+                    "Content:",
+                    document["content"],
+                ]
+            )
+        )
+    if document_lines:
+        messages.append(
+            {
+                "role": "system",
+                "content": (
+                    "The user uploaded reference documents. Use the provided content "
+                    "when answering, cite them as 'uploaded document', and prefer the "
+                    "user's own wording when summarising.\n\n" + "\n\n".join(document_lines)
+                ),
+            }
+        )
     context_lines = []
     for result in search_results:
         context_lines.append(f"Title: {result.title}\nURL: {result.url}\nSnippet: {result.snippet}")
@@ -360,6 +494,7 @@ async def chat(request: ChatRequest) -> StreamingResponse:
     search_results: List[SearchResult] = []
     search_provider: Optional[str] = None
     auto_search_triggered = False
+    documents = _resolve_documents(request.documents)
     if request.mode == "search_duckduckgo":
         search_provider = "duckduckgo"
         search_results = _perform_duckduckgo_search(request.message)
@@ -372,7 +507,7 @@ async def chat(request: ChatRequest) -> StreamingResponse:
             auto_search_triggered = True
             search_results = _perform_serpapi_search(request.message)
 
-    messages = _build_messages(request, search_results)
+    messages = _build_messages(request, search_results, documents)
 
     def _event_stream() -> Iterator[str]:
         metadata = {
@@ -381,6 +516,10 @@ async def chat(request: ChatRequest) -> StreamingResponse:
             "search_results": [result.model_dump() for result in search_results],
             "mode": request.mode,
             "auto_search_triggered": auto_search_triggered,
+            "documents": [
+                {"id": document["id"], "filename": document["filename"]}
+                for document in documents
+            ],
         }
         yield _format_sse_event("meta", metadata)
         try:

--- a/app/main.py
+++ b/app/main.py
@@ -6,7 +6,7 @@ import os
 from pathlib import Path
 from typing import Iterable, List, Literal, Optional
 
-import requests
+from duckduckgo_search import DDGS
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
@@ -104,45 +104,40 @@ async def index() -> FileResponse:
 def _perform_search(query: str, max_results: int = 3) -> List[SearchResult]:
     """Query DuckDuckGo for lightweight search snippets."""
 
-    url = "https://api.duckduckgo.com/"
-    params = {
-        "q": query,
-        "format": "json",
-        "no_html": 1,
-        "no_redirect": 1,
-    }
-    try:
-        response = requests.get(url, params=params, timeout=10)
-        response.raise_for_status()
-    except requests.RequestException as exc:  # pragma: no cover - network failure path
-        logger.warning("Search request failed: %s", exc)
+    query = query.strip()
+    if not query:
         return []
 
-    payload = response.json()
-    related_topics = payload.get("RelatedTopics", [])
-    results: List[SearchResult] = []
-    for topic in related_topics:
-        if "Text" in topic and "FirstURL" in topic:
-            results.append(
-                SearchResult(
-                    title=topic.get("Text", ""),
-                    snippet=topic.get("Text", ""),
-                    url=topic.get("FirstURL", ""),
-                )
+    def _fetch(region: str) -> List[SearchResult]:
+        with DDGS(timeout=10) as ddgs:
+            hits = ddgs.text(
+                query,
+                region=region,
+                safesearch="moderate",
+                max_results=max_results,
             )
-        elif "Topics" in topic:
-            for subtopic in topic.get("Topics", []):
-                if "Text" in subtopic and "FirstURL" in subtopic:
-                    results.append(
-                        SearchResult(
-                            title=subtopic.get("Text", ""),
-                            snippet=subtopic.get("Text", ""),
-                            url=subtopic.get("FirstURL", ""),
-                        )
-                    )
-        if len(results) >= max_results:
-            break
-    return results[:max_results]
+            results: List[SearchResult] = []
+            for item in hits:
+                url = item.get("href", "").strip()
+                if not url:
+                    continue
+                title = item.get("title") or item.get("body") or url
+                snippet = item.get("body", "")
+                results.append(
+                    SearchResult(title=title.strip(), snippet=snippet.strip(), url=url)
+                )
+                if len(results) >= max_results:
+                    break
+            return results
+
+    try:
+        results = _fetch("tw-tzh")
+        if not results:
+            results = _fetch("wt-wt")
+        return results
+    except Exception as exc:  # pragma: no cover - network failure path
+        logger.warning("Search request failed: %s", exc)
+        return []
 
 
 def _build_messages(request: ChatRequest, search_results: Iterable[SearchResult]) -> List[dict]:

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,213 @@
+"""FastAPI backend for GPT-4o powered chatbot."""
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Iterable, List, Literal, Optional
+
+import requests
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+from openai import OpenAI
+from pydantic import BaseModel, Field, validator
+
+logger = logging.getLogger(__name__)
+
+API_TITLE = "GPT-4o Chatbot"
+API_DESCRIPTION = (
+    "Backend service that proxies chat requests to GPT-4o and optionally "
+    "enriches prompts with web search snippets."
+)
+
+app = FastAPI(title=API_TITLE, description=API_DESCRIPTION)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+FRONTEND_DIR = Path(__file__).resolve().parent.parent / "frontend"
+if FRONTEND_DIR.exists():
+    app.mount("/static", StaticFiles(directory=FRONTEND_DIR), name="static")
+
+SYSTEM_PROMPT = (
+    "You are a helpful bilingual assistant that can answer in Traditional "
+    "Chinese and English. When web search context is provided, cite it "
+    "succinctly in the reply."
+)
+
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+client: Optional[OpenAI]
+if OPENAI_API_KEY:
+    client = OpenAI(api_key=OPENAI_API_KEY)
+else:
+    client = None
+    logger.warning("OPENAI_API_KEY not found. LLM requests will fail until it is set.")
+
+
+class SearchResult(BaseModel):
+    """Represents a single web search snippet."""
+
+    title: str
+    snippet: str
+    url: str
+
+
+class ChatMessage(BaseModel):
+    """Chat message exchanged with the client."""
+
+    role: Literal["system", "user", "assistant"]
+    content: str
+
+
+class ChatRequest(BaseModel):
+    """Incoming chat payload from the front-end."""
+
+    message: str = Field(..., description="The end-user prompt.")
+    mode: Literal["llm_only", "search"] = Field(
+        "llm_only", description="Choose between pure LLM or search-assisted mode."
+    )
+    history: List[ChatMessage] = Field(
+        default_factory=list,
+        description="Conversation history to maintain context across turns.",
+    )
+
+    @validator("history", each_item=True)
+    def _strip_empty_history(cls, msg: ChatMessage) -> ChatMessage:
+        if not msg.content:
+            raise ValueError("History messages cannot be empty.")
+        return msg
+
+
+class ChatResponse(BaseModel):
+    """Response returned to the front-end."""
+
+    reply: str
+    used_search: bool
+    search_results: List[SearchResult] = Field(default_factory=list)
+
+
+@app.get("/", include_in_schema=False)
+async def index() -> FileResponse:
+    """Serve the single-page front-end application."""
+    index_file = FRONTEND_DIR / "index.html"
+    if not index_file.exists():
+        raise HTTPException(status_code=404, detail="Front-end not found.")
+    return FileResponse(index_file)
+
+
+def _perform_search(query: str, max_results: int = 3) -> List[SearchResult]:
+    """Query DuckDuckGo for lightweight search snippets."""
+
+    url = "https://api.duckduckgo.com/"
+    params = {
+        "q": query,
+        "format": "json",
+        "no_html": 1,
+        "no_redirect": 1,
+    }
+    try:
+        response = requests.get(url, params=params, timeout=10)
+        response.raise_for_status()
+    except requests.RequestException as exc:  # pragma: no cover - network failure path
+        logger.warning("Search request failed: %s", exc)
+        return []
+
+    payload = response.json()
+    related_topics = payload.get("RelatedTopics", [])
+    results: List[SearchResult] = []
+    for topic in related_topics:
+        if "Text" in topic and "FirstURL" in topic:
+            results.append(
+                SearchResult(
+                    title=topic.get("Text", ""),
+                    snippet=topic.get("Text", ""),
+                    url=topic.get("FirstURL", ""),
+                )
+            )
+        elif "Topics" in topic:
+            for subtopic in topic.get("Topics", []):
+                if "Text" in subtopic and "FirstURL" in subtopic:
+                    results.append(
+                        SearchResult(
+                            title=subtopic.get("Text", ""),
+                            snippet=subtopic.get("Text", ""),
+                            url=subtopic.get("FirstURL", ""),
+                        )
+                    )
+        if len(results) >= max_results:
+            break
+    return results[:max_results]
+
+
+def _build_messages(request: ChatRequest, search_results: Iterable[SearchResult]) -> List[dict]:
+    """Compose the message array sent to GPT-4o."""
+
+    messages: List[dict] = [{"role": "system", "content": SYSTEM_PROMPT}]
+    messages.extend(message.dict() for message in request.history)
+    context_lines = []
+    for result in search_results:
+        context_lines.append(f"Title: {result.title}\nURL: {result.url}\nSnippet: {result.snippet}")
+    if context_lines:
+        context_blob = "\n\n".join(context_lines)
+        messages.append(
+            {
+                "role": "system",
+                "content": (
+                    "Web search results were found for the current question. "
+                    "Incorporate the following evidence when helpful and cite the source URLs:\n"
+                    f"{context_blob}"
+                ),
+            }
+        )
+    messages.append({"role": "user", "content": request.message})
+    return messages
+
+
+def _run_llm(messages: List[dict]) -> str:
+    """Send messages to GPT-4o and extract the assistant reply."""
+
+    if client is None:
+        raise HTTPException(
+            status_code=500,
+            detail="OPENAI_API_KEY is not configured on the server.",
+        )
+    try:
+        response = client.responses.create(model="gpt-4o", messages=messages)
+    except Exception as exc:  # pragma: no cover - network failure path
+        logger.exception("LLM request failed")
+        raise HTTPException(status_code=502, detail=f"LLM request failed: {exc}") from exc
+
+    if hasattr(response, "output_text") and response.output_text:
+        return response.output_text
+
+    collected_parts: List[str] = []
+    for item in getattr(response, "output", []):
+        if item.get("type") == "message":
+            for content in item.get("content", []):
+                if content.get("type") == "output_text":
+                    collected_parts.append(content.get("text", ""))
+    if not collected_parts:
+        raise HTTPException(status_code=502, detail="LLM returned an empty response.")
+    return "".join(collected_parts)
+
+
+@app.post("/chat", response_model=ChatResponse)
+async def chat(request: ChatRequest) -> ChatResponse:
+    """Primary chat endpoint used by the front-end."""
+
+    search_results: List[SearchResult] = []
+    if request.mode == "search":
+        search_results = _perform_search(request.message)
+
+    messages = _build_messages(request, search_results)
+    reply = _run_llm(messages)
+    return ChatResponse(reply=reply, used_search=bool(search_results), search_results=search_results)
+
+
+__all__ = ["app"]

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -313,6 +313,7 @@
         let assistantMessage;
         let finalReply = "";
         let receivedDone = false;
+        let pendingSearchResults = null;
 
         try {
           const response = await fetch("/chat", {
@@ -379,7 +380,7 @@
 
               if (eventType === "meta") {
                 if (parsed.used_search && Array.isArray(parsed.search_results)) {
-                  renderSearchResults(assistantMessage.wrapper, parsed.search_results);
+                  pendingSearchResults = parsed.search_results;
                 }
               } else if (eventType === "delta") {
                 if (parsed.text) {
@@ -392,6 +393,9 @@
                   finalReply = parsed.text;
                   assistantMessage.textEl.textContent = finalReply;
                   chatLog.scrollTop = chatLog.scrollHeight;
+                }
+                if (pendingSearchResults && pendingSearchResults.length) {
+                  renderSearchResults(assistantMessage.wrapper, pendingSearchResults);
                 }
                 receivedDone = true;
               } else if (eventType === "error") {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -247,6 +247,8 @@
         background: rgba(15, 23, 42, 0.92);
         display: grid;
         gap: 14px;
+        max-height: min(320px, 45vh);
+        overflow-y: auto;
       }
 
       textarea {
@@ -339,6 +341,8 @@
         display: flex;
         flex-direction: column;
         gap: 8px;
+        max-height: 160px;
+        overflow-y: auto;
       }
 
       .upload-item {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -325,22 +325,26 @@
         search_auto: "正在判斷是否需要搜尋並產生回應...",
       };
 
-      function scrollToBottom({ smooth = false } = {}) {
-        const behavior = smooth ? "smooth" : "auto";
-        const targetTop = chatLog.scrollHeight;
-        if (typeof chatLog.scrollTo === "function") {
-          chatLog.scrollTo({ top: targetTop, behavior });
-        } else {
-          chatLog.scrollTop = targetTop;
-        }
-      }
-
       function renderMarkdown(markdownText) {
         if (!markdownText) {
           return "";
         }
         const html = marked.parse(markdownText);
         return DOMPurify.sanitize(html);
+      }
+
+      function pinMessageToTop(wrapper) {
+        requestAnimationFrame(() => {
+          if (typeof wrapper.scrollIntoView === "function") {
+            wrapper.scrollIntoView({ block: "start", inline: "nearest", behavior: "auto" });
+          } else {
+            const targetTop = Math.max(
+              0,
+              wrapper.offsetTop - chatLog.offsetTop - 16
+            );
+            chatLog.scrollTop = targetTop;
+          }
+        });
       }
 
       function createMessage(role, initialText = "") {
@@ -355,7 +359,9 @@
         }
         wrapper.appendChild(textEl);
         chatLog.appendChild(wrapper);
-        scrollToBottom();
+        if (role === "user") {
+          pinMessageToTop(wrapper);
+        }
         return { wrapper, textEl };
       }
 
@@ -409,7 +415,6 @@
         resultsBlock.appendChild(heading);
         resultsBlock.appendChild(list);
         wrapper.appendChild(resultsBlock);
-        scrollToBottom();
       }
 
       async function sendMessage(event) {
@@ -518,13 +523,11 @@
                 if (parsed.text) {
                   finalReply += parsed.text;
                   assistantMessage.textEl.innerHTML = renderMarkdown(finalReply);
-                  scrollToBottom({ smooth: true });
                 }
               } else if (eventType === "done") {
                 if (typeof parsed.text === "string") {
                   finalReply = parsed.text;
                   assistantMessage.textEl.innerHTML = renderMarkdown(finalReply);
-                  scrollToBottom({ smooth: true });
                 }
                 if (
                   pendingSearchResults &&
@@ -537,7 +540,6 @@
                     pendingSearchResults.provider || null,
                     { autoTriggered: Boolean(pendingSearchResults.autoTriggered) }
                   );
-                  scrollToBottom({ smooth: true });
                 }
                 receivedDone = true;
               } else if (eventType === "error") {
@@ -572,7 +574,6 @@
             assistantMessage = createMessage("assistant", "");
           }
           assistantMessage.textEl.textContent = `⚠️ ${error.message}`;
-          scrollToBottom({ smooth: true });
           statusEl.textContent = "錯誤";
         } finally {
           submitButton.disabled = false;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -287,6 +287,10 @@
             <input type="radio" name="mode" value="search_serpapi" />
             網頁查詢（SerpAPI） + LLM
           </label>
+          <label>
+            <input type="radio" name="mode" value="search_auto" />
+            網頁查詢（自動判斷） + LLM
+          </label>
         </div>
       </header>
       <main id="chat-log" aria-live="polite"></main>
@@ -321,6 +325,7 @@
         llm_only: "正在產生回應...",
         search_duckduckgo: "正在以 DuckDuckGo 搜尋並產生回應...",
         search_serpapi: "正在以 SerpAPI 搜尋並產生回應...",
+        search_auto: "正在判斷是否需要搜尋並產生回應...",
       };
 
       function renderMarkdown(markdownText) {
@@ -406,7 +411,12 @@
 
       chatLog.addEventListener("scroll", handleScroll, { passive: true });
 
-      function renderSearchResults(wrapper, searchResults = [], provider = null) {
+      function renderSearchResults(
+        wrapper,
+        searchResults = [],
+        provider = null,
+        { autoTriggered = false } = {}
+      ) {
         const existing = wrapper.querySelector(".search-results");
         if (existing) {
           existing.remove();
@@ -423,7 +433,9 @@
         if (provider === "duckduckgo") {
           providerLabel = "DuckDuckGo 網頁查詢結果";
         } else if (provider === "serpapi") {
-          providerLabel = "SerpAPI 網頁查詢結果";
+          providerLabel = autoTriggered
+            ? "SerpAPI（自動判斷）網頁查詢結果"
+            : "SerpAPI 網頁查詢結果";
         }
         heading.textContent = `🔎 使用了${providerLabel}：`;
         const list = document.createElement("ul");
@@ -541,9 +553,18 @@
                     results: Array.isArray(parsed.search_results)
                       ? parsed.search_results
                       : [],
+                    autoTriggered: Boolean(parsed.auto_search_triggered),
                   };
                 } else {
                   pendingSearchResults = null;
+                }
+
+                if (parsed.mode === "search_auto") {
+                  if (parsed.auto_search_triggered) {
+                    statusEl.textContent = "偵測到需要搜尋，正在以 SerpAPI 搜尋並產生回應...";
+                  } else {
+                    statusEl.textContent = "判斷不需即時搜尋，使用 LLM 回覆中...";
+                  }
                 }
               } else if (eventType === "delta") {
                 if (parsed.text) {
@@ -565,7 +586,8 @@
                   renderSearchResults(
                     assistantMessage.wrapper,
                     pendingSearchResults.results,
-                    pendingSearchResults.provider || null
+                    pendingSearchResults.provider || null,
+                    { autoTriggered: Boolean(pendingSearchResults.autoTriggered) }
                   );
                 }
                 receivedDone = true;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -77,7 +77,7 @@
         max-width: 80%;
         padding: 14px 18px;
         border-radius: 16px;
-        line-height: 1.5;
+        line-height: 1.35;
         box-shadow: 0 14px 32px rgba(15, 23, 42, 0.25);
         display: flex;
         flex-direction: column;
@@ -85,12 +85,16 @@
       }
 
       .message-text {
-        white-space: pre-wrap;
+        white-space: normal;
         word-break: break-word;
       }
 
+      .message.user .message-text {
+        white-space: pre-wrap;
+      }
+
       .message-text p {
-        margin: 0 0 0.75em;
+        margin: 0 0 0.5em;
       }
 
       .message-text p:last-child {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -243,6 +243,19 @@
       const messageInput = document.getElementById("message-input");
       const statusEl = document.getElementById("status");
       let history = [];
+      let activeAnchor = null;
+
+      function scrollToAnchor(smooth = true) {
+        if (!activeAnchor) {
+          return;
+        }
+        const top = Math.max(activeAnchor.offsetTop - 12, 0);
+        if (typeof chatLog.scrollTo === "function") {
+          chatLog.scrollTo({ top, behavior: smooth ? "smooth" : "auto" });
+        } else {
+          chatLog.scrollTop = top;
+        }
+      }
 
       function createMessage(role, initialText = "") {
         const wrapper = document.createElement("div");
@@ -252,7 +265,12 @@
         textEl.textContent = initialText;
         wrapper.appendChild(textEl);
         chatLog.appendChild(wrapper);
-        chatLog.scrollTop = chatLog.scrollHeight;
+        if (role === "user") {
+          activeAnchor = wrapper;
+          scrollToAnchor(true);
+        } else {
+          scrollToAnchor(false);
+        }
         return { wrapper, textEl };
       }
 
@@ -293,7 +311,7 @@
         resultsBlock.appendChild(heading);
         resultsBlock.appendChild(list);
         wrapper.appendChild(resultsBlock);
-        chatLog.scrollTop = chatLog.scrollHeight;
+        scrollToAnchor(false);
       }
 
       async function sendMessage(event) {
@@ -386,13 +404,13 @@
                 if (parsed.text) {
                   finalReply += parsed.text;
                   assistantMessage.textEl.textContent = finalReply;
-                  chatLog.scrollTop = chatLog.scrollHeight;
+                  scrollToAnchor(false);
                 }
               } else if (eventType === "done") {
                 if (typeof parsed.text === "string") {
                   finalReply = parsed.text;
                   assistantMessage.textEl.textContent = finalReply;
-                  chatLog.scrollTop = chatLog.scrollHeight;
+                  scrollToAnchor(false);
                 }
                 if (pendingSearchResults && pendingSearchResults.length) {
                   renderSearchResults(assistantMessage.wrapper, pendingSearchResults);
@@ -430,6 +448,7 @@
             assistantMessage = createMessage("assistant", "");
           }
           assistantMessage.textEl.textContent = `⚠️ ${error.message}`;
+          scrollToAnchor(false);
           statusEl.textContent = "錯誤";
         } finally {
           submitButton.disabled = false;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -89,6 +89,62 @@
         word-break: break-word;
       }
 
+      .message-text p {
+        margin: 0 0 0.75em;
+      }
+
+      .message-text p:last-child {
+        margin-bottom: 0;
+      }
+
+      .message-text ul,
+      .message-text ol {
+        margin: 0.5em 0;
+        padding-left: 1.25em;
+      }
+
+      .message-text li {
+        margin: 0.25em 0;
+      }
+
+      .message-text code {
+        font-family: "Fira Code", "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+        background: rgba(15, 23, 42, 0.65);
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        border-radius: 6px;
+        padding: 0.15em 0.4em;
+        font-size: 0.95em;
+      }
+
+      .message-text pre {
+        font-family: "Fira Code", "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+        background: rgba(15, 23, 42, 0.8);
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        border-radius: 10px;
+        padding: 1em;
+        margin: 0.75em 0;
+        overflow-x: auto;
+        box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.12);
+      }
+
+      .message-text pre code {
+        background: none;
+        border: none;
+        padding: 0;
+        font-size: 0.95em;
+      }
+
+      .message-text blockquote {
+        margin: 0.75em 0;
+        padding-left: 1em;
+        border-left: 4px solid rgba(148, 163, 184, 0.35);
+        color: rgba(226, 232, 240, 0.85);
+      }
+
+      .message-text a {
+        color: #38bdf8;
+      }
+
       .message.user {
         align-self: flex-end;
         background: linear-gradient(135deg, rgba(59, 130, 246, 0.9), rgba(37, 99, 235, 0.95));
@@ -237,13 +293,28 @@
       </form>
     </div>
 
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.5/dist/purify.min.js"></script>
     <script>
+      marked.setOptions({
+        breaks: true,
+        gfm: true,
+      });
+
       const chatLog = document.getElementById("chat-log");
       const form = document.getElementById("chat-form");
       const messageInput = document.getElementById("message-input");
       const statusEl = document.getElementById("status");
       let history = [];
       let activeAnchor = null;
+
+      function renderMarkdown(markdownText) {
+        if (!markdownText) {
+          return "";
+        }
+        const html = marked.parse(markdownText);
+        return DOMPurify.sanitize(html);
+      }
 
       function scrollToAnchor(smooth = true) {
         if (!activeAnchor) {
@@ -262,7 +333,11 @@
         wrapper.className = `message ${role}`;
         const textEl = document.createElement("div");
         textEl.className = "message-text";
-        textEl.textContent = initialText;
+        if (role === "assistant") {
+          textEl.innerHTML = renderMarkdown(initialText);
+        } else {
+          textEl.textContent = initialText;
+        }
         wrapper.appendChild(textEl);
         chatLog.appendChild(wrapper);
         if (role === "user") {
@@ -403,13 +478,13 @@
               } else if (eventType === "delta") {
                 if (parsed.text) {
                   finalReply += parsed.text;
-                  assistantMessage.textEl.textContent = finalReply;
+                  assistantMessage.textEl.innerHTML = renderMarkdown(finalReply);
                   scrollToAnchor(false);
                 }
               } else if (eventType === "done") {
                 if (typeof parsed.text === "string") {
                   finalReply = parsed.text;
-                  assistantMessage.textEl.textContent = finalReply;
+                  assistantMessage.textEl.innerHTML = renderMarkdown(finalReply);
                   scrollToAnchor(false);
                 }
                 if (pendingSearchResults && pendingSearchResults.length) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -78,9 +78,15 @@
         padding: 14px 18px;
         border-radius: 16px;
         line-height: 1.5;
+        box-shadow: 0 14px 32px rgba(15, 23, 42, 0.25);
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      .message-text {
         white-space: pre-wrap;
         word-break: break-word;
-        box-shadow: 0 14px 32px rgba(15, 23, 42, 0.25);
       }
 
       .message.user {
@@ -238,42 +244,55 @@
       const statusEl = document.getElementById("status");
       let history = [];
 
-      function appendMessage(role, content, searchResults = []) {
+      function createMessage(role, initialText = "") {
         const wrapper = document.createElement("div");
         wrapper.className = `message ${role}`;
-        wrapper.textContent = content;
+        const textEl = document.createElement("div");
+        textEl.className = "message-text";
+        textEl.textContent = initialText;
+        wrapper.appendChild(textEl);
+        chatLog.appendChild(wrapper);
+        chatLog.scrollTop = chatLog.scrollHeight;
+        return { wrapper, textEl };
+      }
 
-        if (role === "assistant" && searchResults.length) {
-          const resultsBlock = document.createElement("div");
-          resultsBlock.className = "search-results";
-          const heading = document.createElement("p");
-          heading.textContent = "🔎 使用了即時網頁查詢結果：";
-          const list = document.createElement("ul");
-
-          searchResults.forEach((item) => {
-            const listItem = document.createElement("li");
-            const link = document.createElement("a");
-            link.href = item.url;
-            link.target = "_blank";
-            link.rel = "noopener noreferrer";
-            link.textContent = item.title || item.url;
-            listItem.appendChild(link);
-
-            if (item.snippet) {
-              const snippet = document.createElement("p");
-              snippet.textContent = item.snippet;
-              listItem.appendChild(snippet);
-            }
-
-            list.appendChild(listItem);
-          });
-
-          resultsBlock.appendChild(heading);
-          resultsBlock.appendChild(list);
-          wrapper.appendChild(resultsBlock);
+      function renderSearchResults(wrapper, searchResults = []) {
+        const existing = wrapper.querySelector(".search-results");
+        if (existing) {
+          existing.remove();
         }
 
-        chatLog.appendChild(wrapper);
+        if (!searchResults.length) {
+          return;
+        }
+
+        const resultsBlock = document.createElement("div");
+        resultsBlock.className = "search-results";
+        const heading = document.createElement("p");
+        heading.textContent = "🔎 使用了即時網頁查詢結果：";
+        const list = document.createElement("ul");
+
+        searchResults.forEach((item) => {
+          const listItem = document.createElement("li");
+          const link = document.createElement("a");
+          link.href = item.url;
+          link.target = "_blank";
+          link.rel = "noopener noreferrer";
+          link.textContent = item.title || item.url;
+          listItem.appendChild(link);
+
+          if (item.snippet) {
+            const snippet = document.createElement("p");
+            snippet.textContent = item.snippet;
+            listItem.appendChild(snippet);
+          }
+
+          list.appendChild(listItem);
+        });
+
+        resultsBlock.appendChild(heading);
+        resultsBlock.appendChild(list);
+        wrapper.appendChild(resultsBlock);
         chatLog.scrollTop = chatLog.scrollHeight;
       }
 
@@ -285,10 +304,15 @@
         }
 
         const mode = document.querySelector('input[name="mode"]:checked').value;
-        appendMessage("user", message);
+        createMessage("user", message);
         history.push({ role: "user", content: message });
-        form.querySelector("button").disabled = true;
+        const submitButton = form.querySelector("button");
+        submitButton.disabled = true;
         statusEl.textContent = mode === "search" ? "正在搜尋並產生回應..." : "正在產生回應...";
+
+        let assistantMessage;
+        let finalReply = "";
+        let receivedDone = false;
 
         try {
           const response = await fetch("/chat", {
@@ -297,21 +321,114 @@
             body: JSON.stringify({ message, mode, history }),
           });
 
-          if (!response.ok) {
-            const error = await response.json().catch(() => ({}));
-            throw new Error(error.detail || "伺服器發生錯誤");
+          if (!response.ok || !response.body) {
+            let errorDetail = "伺服器發生錯誤";
+            try {
+              const payload = await response.json();
+              if (payload && payload.detail) {
+                errorDetail = payload.detail;
+              }
+            } catch (err) {
+              try {
+                errorDetail = await response.text();
+              } catch (err2) {
+                // ignore parsing errors
+              }
+            }
+            throw new Error(errorDetail || "伺服器發生錯誤");
           }
 
-          const data = await response.json();
-          appendMessage("assistant", data.reply, data.used_search ? data.search_results : []);
-          history.push({ role: "assistant", content: data.reply });
+          assistantMessage = createMessage("assistant", "");
+
+          const reader = response.body.getReader();
+          const decoder = new TextDecoder();
+          let buffer = "";
+
+          const processBuffer = () => {
+            let boundary;
+            while ((boundary = buffer.indexOf("\n\n")) !== -1) {
+              const rawEvent = buffer.slice(0, boundary).trim();
+              buffer = buffer.slice(boundary + 2);
+              if (!rawEvent) {
+                continue;
+              }
+
+              const lines = rawEvent.split("\n");
+              let eventType = "message";
+              let dataPayload = "";
+              for (const line of lines) {
+                if (line.startsWith("event:")) {
+                  eventType = line.slice(6).trim();
+                } else if (line.startsWith("data:")) {
+                  const value = line.slice(5).trim();
+                  dataPayload += (dataPayload ? "\n" : "") + value;
+                }
+              }
+
+              if (!dataPayload) {
+                continue;
+              }
+
+              let parsed;
+              try {
+                parsed = JSON.parse(dataPayload);
+              } catch (parseError) {
+                console.error("無法解析伺服器回傳：", parseError);
+                continue;
+              }
+
+              if (eventType === "meta") {
+                if (parsed.used_search && Array.isArray(parsed.search_results)) {
+                  renderSearchResults(assistantMessage.wrapper, parsed.search_results);
+                }
+              } else if (eventType === "delta") {
+                if (parsed.text) {
+                  finalReply += parsed.text;
+                  assistantMessage.textEl.textContent = finalReply;
+                  chatLog.scrollTop = chatLog.scrollHeight;
+                }
+              } else if (eventType === "done") {
+                if (typeof parsed.text === "string") {
+                  finalReply = parsed.text;
+                  assistantMessage.textEl.textContent = finalReply;
+                  chatLog.scrollTop = chatLog.scrollHeight;
+                }
+                receivedDone = true;
+              } else if (eventType === "error") {
+                throw new Error(parsed.message || "伺服器發生錯誤");
+              }
+            }
+          };
+
+          while (true) {
+            const { value, done } = await reader.read();
+            if (done) {
+              break;
+            }
+            buffer += decoder.decode(value, { stream: true });
+            processBuffer();
+          }
+
+          buffer += decoder.decode();
+          processBuffer();
+
+          if (!receivedDone) {
+            throw new Error("回覆未完整傳送");
+          }
+
+          if (finalReply) {
+            history.push({ role: "assistant", content: finalReply });
+          }
           statusEl.textContent = "完成";
         } catch (error) {
           console.error(error);
-          appendMessage("assistant", `⚠️ ${error.message}`);
+          if (!assistantMessage) {
+            assistantMessage = createMessage("assistant", "");
+          }
+          assistantMessage.textEl.textContent = `⚠️ ${error.message}`;
           statusEl.textContent = "錯誤";
         } finally {
-          form.querySelector("button").disabled = false;
+          submitButton.disabled = false;
           messageInput.value = "";
           messageInput.focus();
         }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -149,6 +149,27 @@
         color: #38bdf8;
       }
 
+      .attachments-list {
+        list-style: none;
+        margin: 8px 0 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        font-size: 0.8rem;
+        color: rgba(226, 232, 240, 0.82);
+      }
+
+      .attachments-list li {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+      }
+
+      .attachments-list li::before {
+        content: "📎";
+      }
+
       .message.user {
         align-self: flex-end;
         background: linear-gradient(135deg, rgba(59, 130, 246, 0.9), rgba(37, 99, 235, 0.95));
@@ -199,12 +220,33 @@
         color: rgba(226, 232, 240, 0.82);
       }
 
+      .document-usage {
+        margin-top: 12px;
+        padding: 10px 12px;
+        border-radius: 10px;
+        background: rgba(15, 23, 42, 0.65);
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        font-size: 0.8rem;
+        color: rgba(226, 232, 240, 0.85);
+      }
+
+      .document-usage p {
+        margin: 0;
+        font-weight: 600;
+        color: #a5b4fc;
+      }
+
+      .document-usage ul {
+        margin: 8px 0 0;
+        padding-left: 18px;
+      }
+
       form {
         padding: 20px 24px;
         border-top: 1px solid rgba(148, 163, 184, 0.16);
         background: rgba(15, 23, 42, 0.92);
         display: grid;
-        gap: 12px;
+        gap: 14px;
       }
 
       textarea {
@@ -256,6 +298,75 @@
         min-height: 1em;
       }
 
+      .upload-section {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      .upload-section label {
+        font-size: 0.95rem;
+        font-weight: 600;
+      }
+
+      .upload-controls {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+        flex-wrap: wrap;
+      }
+
+      .upload-controls input[type="file"] {
+        color: inherit;
+      }
+
+      .upload-help {
+        font-size: 0.8rem;
+        color: rgba(148, 163, 184, 0.75);
+        margin: 0;
+      }
+
+      .upload-status {
+        font-size: 0.8rem;
+        color: rgba(148, 163, 184, 0.9);
+        min-height: 1em;
+      }
+
+      .uploads-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      .upload-item {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+        padding: 8px 12px;
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        border-radius: 10px;
+        background: rgba(15, 23, 42, 0.6);
+        font-size: 0.85rem;
+      }
+
+      .upload-item span {
+        flex: 1;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .upload-item button {
+        padding: 6px 14px;
+        font-size: 0.8rem;
+        border-radius: 999px;
+        background: rgba(239, 68, 68, 0.85);
+        color: #f8fafc;
+      }
+
       @media (max-width: 600px) {
         header {
           flex-direction: column;
@@ -295,6 +406,20 @@
       </header>
       <main id="chat-log" aria-live="polite"></main>
       <form id="chat-form">
+        <div class="upload-section">
+          <label for="file-input">上傳參考檔案</label>
+          <div class="upload-controls">
+            <input
+              type="file"
+              id="file-input"
+              accept=".pdf,.txt,.md,.markdown,.csv"
+              multiple
+            />
+          </div>
+          <p class="upload-help">支援 PDF 與純文字檔，內容將提供給模型參考。</p>
+          <div class="upload-status" id="upload-status"></div>
+          <ul class="uploads-list" id="uploads-list"></ul>
+        </div>
         <textarea
           id="message-input"
           placeholder="輸入您的問題或想聊的話題..."
@@ -317,7 +442,11 @@
       const form = document.getElementById("chat-form");
       const messageInput = document.getElementById("message-input");
       const statusEl = document.getElementById("status");
+      const fileInput = document.getElementById("file-input");
+      const uploadsList = document.getElementById("uploads-list");
+      const uploadStatusEl = document.getElementById("upload-status");
       let history = [];
+      let uploadedDocuments = [];
       const modeStatusText = {
         llm_only: "正在產生回應...",
         search_duckduckgo: "正在以 DuckDuckGo 搜尋並產生回應...",
@@ -335,6 +464,87 @@
 
       let anchorMessage = null;
       let anchorAlignedForReply = false;
+
+      function updateUploadsList() {
+        uploadsList.innerHTML = "";
+        if (!uploadedDocuments.length) {
+          return;
+        }
+
+        uploadedDocuments.forEach((doc, index) => {
+          const item = document.createElement("li");
+          item.className = "upload-item";
+
+          const nameSpan = document.createElement("span");
+          nameSpan.textContent = doc.filename;
+          item.appendChild(nameSpan);
+
+          const removeButton = document.createElement("button");
+          removeButton.type = "button";
+          removeButton.textContent = "移除";
+          removeButton.addEventListener("click", () => {
+            uploadedDocuments = uploadedDocuments.filter((_, i) => i !== index);
+            updateUploadsList();
+          });
+          item.appendChild(removeButton);
+
+          uploadsList.appendChild(item);
+        });
+      }
+
+      async function handleFileSelection(event) {
+        const files = Array.from(event.target.files || []);
+        if (!files.length) {
+          return;
+        }
+
+        for (const file of files) {
+          const formData = new FormData();
+          formData.append("file", file);
+          try {
+            uploadStatusEl.textContent = `正在上傳 ${file.name}...`;
+            const response = await fetch("/upload", {
+              method: "POST",
+              body: formData,
+            });
+            if (!response.ok) {
+              let detail = "檔案上傳失敗";
+              try {
+                const payload = await response.json();
+                if (payload && payload.detail) {
+                  detail = payload.detail;
+                }
+              } catch (err) {
+                // ignore parse errors
+              }
+              throw new Error(detail);
+            }
+            const payload = await response.json();
+            uploadedDocuments.push({
+              id: payload.document_id,
+              filename: payload.filename || file.name,
+              charCount: payload.char_count || 0,
+            });
+            updateUploadsList();
+            uploadStatusEl.textContent = `${file.name} 上傳完成`;
+          } catch (error) {
+            console.error(error);
+            uploadStatusEl.textContent = `上傳失敗：${error.message}`;
+          }
+        }
+
+        setTimeout(() => {
+          uploadStatusEl.textContent = "";
+        }, 4000);
+
+        if (fileInput) {
+          fileInput.value = "";
+        }
+      }
+
+      if (fileInput) {
+        fileInput.addEventListener("change", handleFileSelection);
+      }
 
       function pinMessageToTop(wrapper) {
         requestAnimationFrame(() => {
@@ -358,7 +568,7 @@
         anchorAlignedForReply = true;
       }
 
-      function createMessage(role, initialText = "") {
+      function createMessage(role, initialText = "", options = {}) {
         const wrapper = document.createElement("div");
         wrapper.className = `message ${role}`;
         const textEl = document.createElement("div");
@@ -369,6 +579,9 @@
           textEl.textContent = initialText;
         }
         wrapper.appendChild(textEl);
+        if (role === "user") {
+          renderUserAttachments(wrapper, options.attachments || []);
+        }
         chatLog.appendChild(wrapper);
         if (role === "user") {
           anchorMessage = wrapper;
@@ -376,6 +589,20 @@
           pinMessageToTop(wrapper);
         }
         return { wrapper, textEl };
+      }
+
+      function renderUserAttachments(wrapper, attachments = []) {
+        if (!attachments.length) {
+          return;
+        }
+        const list = document.createElement("ul");
+        list.className = "attachments-list";
+        attachments.forEach((attachment) => {
+          const item = document.createElement("li");
+          item.textContent = attachment.name;
+          list.appendChild(item);
+        });
+        wrapper.appendChild(list);
       }
 
       function renderSearchResults(
@@ -430,6 +657,33 @@
         wrapper.appendChild(resultsBlock);
       }
 
+      function renderDocumentUsage(wrapper, documents = []) {
+        const existing = wrapper.querySelector(".document-usage");
+        if (existing) {
+          existing.remove();
+        }
+        if (!documents.length) {
+          return;
+        }
+
+        const block = document.createElement("div");
+        block.className = "document-usage";
+        const heading = document.createElement("p");
+        heading.textContent = "📎 本次參考了上傳檔案：";
+        const list = document.createElement("ul");
+
+        documents.forEach((doc) => {
+          const listItem = document.createElement("li");
+          const match = uploadedDocuments.find((item) => item.id === doc.id);
+          listItem.textContent = match ? match.filename : doc.filename || doc.id;
+          list.appendChild(listItem);
+        });
+
+        block.appendChild(heading);
+        block.appendChild(list);
+        wrapper.appendChild(block);
+      }
+
       async function sendMessage(event) {
         event.preventDefault();
         const message = messageInput.value.trim();
@@ -438,7 +692,8 @@
         }
 
         const mode = document.querySelector('input[name="mode"]:checked').value;
-        createMessage("user", message);
+        const attachmentsForMessage = uploadedDocuments.map((doc) => ({ name: doc.filename }));
+        createMessage("user", message, { attachments: attachmentsForMessage });
         history.push({ role: "user", content: message });
         const submitButton = form.querySelector("button");
         submitButton.disabled = true;
@@ -448,12 +703,18 @@
         let finalReply = "";
         let receivedDone = false;
         let pendingSearchResults = null;
+        let pendingDocumentUsage = null;
 
         try {
           const response = await fetch("/chat", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ message, mode, history }),
+            body: JSON.stringify({
+              message,
+              mode,
+              history,
+              documents: uploadedDocuments.map((doc) => doc.id),
+            }),
           });
 
           if (!response.ok || !response.body) {
@@ -526,6 +787,12 @@
                   pendingSearchResults = null;
                 }
 
+                if (Array.isArray(parsed.documents)) {
+                  pendingDocumentUsage = parsed.documents;
+                } else {
+                  pendingDocumentUsage = null;
+                }
+
                 if (parsed.mode === "search_auto") {
                   if (parsed.auto_search_triggered) {
                     statusEl.textContent = "偵測到需要搜尋，正在以 SerpAPI 搜尋並產生回應...";
@@ -543,6 +810,12 @@
                   finalReply = parsed.text;
                   assistantMessage.textEl.innerHTML = renderMarkdown(finalReply);
                 }
+                if (pendingDocumentUsage && pendingDocumentUsage.length) {
+                  renderDocumentUsage(
+                    assistantMessage.wrapper,
+                    pendingDocumentUsage
+                  );
+                }
                 if (
                   pendingSearchResults &&
                   Array.isArray(pendingSearchResults.results) &&
@@ -556,6 +829,7 @@
                   );
                 }
                 receivedDone = true;
+                pendingDocumentUsage = null;
               } else if (eventType === "error") {
                 throw new Error(parsed.message || "伺服器發生錯誤");
               }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -325,48 +325,14 @@
         search_auto: "正在判斷是否需要搜尋並產生回應...",
       };
 
-      let anchorMessage = null;
-      let anchorSpacing = 0;
-      let autoScrollEnabled = true;
-      let isProgrammaticScroll = false;
-
-      function scheduleProgrammaticFlagReset() {
-        if (typeof window.requestAnimationFrame === "function") {
-          window.requestAnimationFrame(() => {
-            isProgrammaticScroll = false;
-          });
-        } else {
-          setTimeout(() => {
-            isProgrammaticScroll = false;
-          }, 16);
-        }
-      }
-
-      function performScroll(top, behavior = "auto") {
-        isProgrammaticScroll = true;
+      function scrollToBottom({ smooth = false } = {}) {
+        const behavior = smooth ? "smooth" : "auto";
+        const targetTop = chatLog.scrollHeight;
         if (typeof chatLog.scrollTo === "function") {
-          chatLog.scrollTo({ top, behavior });
+          chatLog.scrollTo({ top: targetTop, behavior });
         } else {
-          chatLog.scrollTop = top;
+          chatLog.scrollTop = targetTop;
         }
-        scheduleProgrammaticFlagReset();
-      }
-
-      function maintainAnchor({ smooth = false } = {}) {
-        if (!anchorMessage || !autoScrollEnabled) {
-          return;
-        }
-        const targetTop = Math.max(anchorMessage.offsetTop - anchorSpacing, 0);
-        if (Math.abs(chatLog.scrollTop - targetTop) > 1) {
-          performScroll(targetTop, smooth ? "smooth" : "auto");
-        }
-      }
-
-      function setAnchor(element) {
-        anchorMessage = element;
-        anchorSpacing = 0;
-        autoScrollEnabled = true;
-        maintainAnchor();
       }
 
       function renderMarkdown(markdownText) {
@@ -389,11 +355,7 @@
         }
         wrapper.appendChild(textEl);
         chatLog.appendChild(wrapper);
-        if (role === "user") {
-          setAnchor(wrapper);
-        } else {
-          maintainAnchor();
-        }
+        scrollToBottom();
         return { wrapper, textEl };
       }
 
@@ -447,33 +409,8 @@
         resultsBlock.appendChild(heading);
         resultsBlock.appendChild(list);
         wrapper.appendChild(resultsBlock);
-        maintainAnchor();
+        scrollToBottom();
       }
-
-      chatLog.addEventListener("scroll", () => {
-        if (!anchorMessage || isProgrammaticScroll) {
-          return;
-        }
-
-        const currentSpacing = anchorMessage.offsetTop - chatLog.scrollTop;
-
-        if (!autoScrollEnabled) {
-          anchorSpacing = currentSpacing;
-          if (Math.abs(currentSpacing) <= 4) {
-            autoScrollEnabled = true;
-            maintainAnchor();
-          }
-          return;
-        }
-
-        if (Math.abs(currentSpacing - anchorSpacing) > 6) {
-          autoScrollEnabled = false;
-          anchorSpacing = currentSpacing;
-          return;
-        }
-
-        anchorSpacing = currentSpacing;
-      });
 
       async function sendMessage(event) {
         event.preventDefault();
@@ -581,13 +518,13 @@
                 if (parsed.text) {
                   finalReply += parsed.text;
                   assistantMessage.textEl.innerHTML = renderMarkdown(finalReply);
-                  maintainAnchor();
+                  scrollToBottom({ smooth: true });
                 }
               } else if (eventType === "done") {
                 if (typeof parsed.text === "string") {
                   finalReply = parsed.text;
                   assistantMessage.textEl.innerHTML = renderMarkdown(finalReply);
-                  maintainAnchor();
+                  scrollToBottom({ smooth: true });
                 }
                 if (
                   pendingSearchResults &&
@@ -600,7 +537,7 @@
                     pendingSearchResults.provider || null,
                     { autoTriggered: Boolean(pendingSearchResults.autoTriggered) }
                   );
-                  maintainAnchor();
+                  scrollToBottom({ smooth: true });
                 }
                 receivedDone = true;
               } else if (eventType === "error") {
@@ -635,7 +572,7 @@
             assistantMessage = createMessage("assistant", "");
           }
           assistantMessage.textEl.textContent = `⚠️ ${error.message}`;
-          maintainAnchor();
+          scrollToBottom({ smooth: true });
           statusEl.textContent = "錯誤";
         } finally {
           submitButton.disabled = false;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -318,9 +318,6 @@
       const messageInput = document.getElementById("message-input");
       const statusEl = document.getElementById("status");
       let history = [];
-      let activeAnchor = null;
-      let autoScrollEnabled = true;
-      let isProgrammaticScroll = false;
       const modeStatusText = {
         llm_only: "正在產生回應...",
         search_duckduckgo: "正在以 DuckDuckGo 搜尋並產生回應...",
@@ -328,46 +325,21 @@
         search_auto: "正在判斷是否需要搜尋並產生回應...",
       };
 
+      function scrollToBottom(smooth = true) {
+        const behavior = smooth ? "smooth" : "auto";
+        if (typeof chatLog.scrollTo === "function") {
+          chatLog.scrollTo({ top: chatLog.scrollHeight, behavior });
+        } else {
+          chatLog.scrollTop = chatLog.scrollHeight;
+        }
+      }
+
       function renderMarkdown(markdownText) {
         if (!markdownText) {
           return "";
         }
         const html = marked.parse(markdownText);
         return DOMPurify.sanitize(html);
-      }
-
-      function getAnchorTop() {
-        if (!activeAnchor || !activeAnchor.isConnected) {
-          return null;
-        }
-        const anchorRect = activeAnchor.getBoundingClientRect();
-        const containerRect = chatLog.getBoundingClientRect();
-        return anchorRect.top - containerRect.top + chatLog.scrollTop;
-      }
-
-      function scrollToAnchor(smooth = true) {
-        if (!activeAnchor || !autoScrollEnabled) {
-          return;
-        }
-        const anchorTop = getAnchorTop();
-        if (anchorTop === null) {
-          return;
-        }
-        const top = Math.max(anchorTop - 12, 0);
-        isProgrammaticScroll = true;
-        if (typeof chatLog.scrollTo === "function") {
-          chatLog.scrollTo({ top, behavior: smooth ? "smooth" : "auto" });
-        } else {
-          chatLog.scrollTop = top;
-        }
-        const resetProgrammaticFlag = () => {
-          isProgrammaticScroll = false;
-        };
-        if (typeof window.requestAnimationFrame === "function") {
-          window.requestAnimationFrame(resetProgrammaticFlag);
-        } else {
-          setTimeout(resetProgrammaticFlag, 50);
-        }
       }
 
       function createMessage(role, initialText = "") {
@@ -382,34 +354,9 @@
         }
         wrapper.appendChild(textEl);
         chatLog.appendChild(wrapper);
-        if (role === "user") {
-          activeAnchor = wrapper;
-          autoScrollEnabled = true;
-          scrollToAnchor(true);
-        } else {
-          scrollToAnchor(false);
-        }
+        scrollToBottom(role === "user");
         return { wrapper, textEl };
       }
-
-      function handleScroll() {
-        if (!activeAnchor || isProgrammaticScroll) {
-          return;
-        }
-        const anchorTop = getAnchorTop();
-        if (anchorTop === null) {
-          return;
-        }
-        const targetTop = Math.max(anchorTop - 12, 0);
-        const distance = Math.abs(chatLog.scrollTop - targetTop);
-        if (autoScrollEnabled && distance > 24) {
-          autoScrollEnabled = false;
-        } else if (!autoScrollEnabled && distance <= 12) {
-          autoScrollEnabled = true;
-        }
-      }
-
-      chatLog.addEventListener("scroll", handleScroll, { passive: true });
 
       function renderSearchResults(
         wrapper,
@@ -461,7 +408,7 @@
         resultsBlock.appendChild(heading);
         resultsBlock.appendChild(list);
         wrapper.appendChild(resultsBlock);
-        scrollToAnchor(false);
+        scrollToBottom(false);
       }
 
       async function sendMessage(event) {
@@ -570,13 +517,13 @@
                 if (parsed.text) {
                   finalReply += parsed.text;
                   assistantMessage.textEl.innerHTML = renderMarkdown(finalReply);
-                  scrollToAnchor(false);
+                  scrollToBottom(false);
                 }
               } else if (eventType === "done") {
                 if (typeof parsed.text === "string") {
                   finalReply = parsed.text;
                   assistantMessage.textEl.innerHTML = renderMarkdown(finalReply);
-                  scrollToAnchor(false);
+                  scrollToBottom(false);
                 }
                 if (
                   pendingSearchResults &&
@@ -623,7 +570,7 @@
             assistantMessage = createMessage("assistant", "");
           }
           assistantMessage.textEl.textContent = `⚠️ ${error.message}`;
-          scrollToAnchor(false);
+          scrollToBottom(false);
           statusEl.textContent = "錯誤";
         } finally {
           submitButton.disabled = false;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -247,14 +247,14 @@
         background: rgba(15, 23, 42, 0.92);
         display: grid;
         gap: 14px;
-        max-height: min(320px, 45vh);
+        max-height: min(214px, 30vh);
         overflow-y: auto;
       }
 
       textarea {
         width: 100%;
         resize: none;
-        min-height: 90px;
+        min-height: 45px;
         padding: 14px;
         border-radius: 12px;
         border: 1px solid rgba(148, 163, 184, 0.25);
@@ -396,22 +396,22 @@
           </label>
           <label>
             <input type="radio" name="mode" value="search_duckduckgo" />
-            網頁查詢（DuckDuckGo） + LLM
+            DuckDuckGo + LLM
           </label>
           <label>
             <input type="radio" name="mode" value="search_serpapi" />
-            網頁查詢（SerpAPI） + LLM
+            SerpAPI + LLM
           </label>
           <label>
             <input type="radio" name="mode" value="search_auto" />
-            網頁查詢（自動判斷） + LLM
+            自動（SerpAPI） + LLM
           </label>
         </div>
       </header>
       <main id="chat-log" aria-live="polite"></main>
       <form id="chat-form">
         <div class="upload-section">
-          <label for="file-input">上傳參考檔案</label>
+          <label for="file-input">附件</label>
           <div class="upload-controls">
             <input
               type="file"
@@ -420,7 +420,7 @@
               multiple
             />
           </div>
-          <p class="upload-help">支援 PDF 與純文字檔，內容將提供給模型參考。</p>
+          <p class="upload-help">支援 PDF、純文字，作為回答參考。</p>
           <div class="upload-status" id="upload-status"></div>
           <ul class="uploads-list" id="uploads-list"></ul>
         </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -311,6 +311,8 @@
       const statusEl = document.getElementById("status");
       let history = [];
       let activeAnchor = null;
+      let autoScrollEnabled = true;
+      let isProgrammaticScroll = false;
 
       function renderMarkdown(markdownText) {
         if (!markdownText) {
@@ -321,14 +323,23 @@
       }
 
       function scrollToAnchor(smooth = true) {
-        if (!activeAnchor) {
+        if (!activeAnchor || !autoScrollEnabled) {
           return;
         }
         const top = Math.max(activeAnchor.offsetTop - 12, 0);
+        isProgrammaticScroll = true;
         if (typeof chatLog.scrollTo === "function") {
           chatLog.scrollTo({ top, behavior: smooth ? "smooth" : "auto" });
         } else {
           chatLog.scrollTop = top;
+        }
+        const resetProgrammaticFlag = () => {
+          isProgrammaticScroll = false;
+        };
+        if (typeof window.requestAnimationFrame === "function") {
+          window.requestAnimationFrame(resetProgrammaticFlag);
+        } else {
+          setTimeout(resetProgrammaticFlag, 50);
         }
       }
 
@@ -346,12 +357,28 @@
         chatLog.appendChild(wrapper);
         if (role === "user") {
           activeAnchor = wrapper;
+          autoScrollEnabled = true;
           scrollToAnchor(true);
         } else {
           scrollToAnchor(false);
         }
         return { wrapper, textEl };
       }
+
+      function handleScroll() {
+        if (!activeAnchor || isProgrammaticScroll) {
+          return;
+        }
+        const anchorTop = Math.max(activeAnchor.offsetTop - 12, 0);
+        const distance = Math.abs(chatLog.scrollTop - anchorTop);
+        if (autoScrollEnabled && distance > 24) {
+          autoScrollEnabled = false;
+        } else if (!autoScrollEnabled && distance <= 12) {
+          autoScrollEnabled = true;
+        }
+      }
+
+      chatLog.addEventListener("scroll", handleScroll, { passive: true });
 
       function renderSearchResults(wrapper, searchResults = []) {
         const existing = wrapper.querySelector(".search-results");

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,306 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GPT-4o Chatbot</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: "Segoe UI", Roboto, "Noto Sans TC", sans-serif;
+        background-color: #0f172a;
+        color: #e2e8f0;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: radial-gradient(circle at top, rgba(59, 130, 246, 0.25), transparent 55%),
+          radial-gradient(circle at bottom, rgba(236, 72, 153, 0.2), transparent 40%),
+          #0f172a;
+      }
+
+      .app {
+        width: min(960px, 92vw);
+        height: min(720px, 92vh);
+        backdrop-filter: blur(18px);
+        background: rgba(15, 23, 42, 0.88);
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        border-radius: 18px;
+        box-shadow: 0 35px 80px rgba(15, 23, 42, 0.55);
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+      }
+
+      header {
+        padding: 18px 24px;
+        border-bottom: 1px solid rgba(148, 163, 184, 0.16);
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+
+      header h1 {
+        margin: 0;
+        font-size: 1.45rem;
+      }
+
+      .mode-select {
+        display: flex;
+        gap: 12px;
+        align-items: center;
+        font-size: 0.95rem;
+      }
+
+      .mode-select label {
+        display: flex;
+        gap: 6px;
+        align-items: center;
+        cursor: pointer;
+      }
+
+      main {
+        flex: 1;
+        padding: 24px;
+        overflow-y: auto;
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+        scroll-behavior: smooth;
+      }
+
+      .message {
+        max-width: 80%;
+        padding: 14px 18px;
+        border-radius: 16px;
+        line-height: 1.5;
+        white-space: pre-wrap;
+        word-break: break-word;
+        box-shadow: 0 14px 32px rgba(15, 23, 42, 0.25);
+      }
+
+      .message.user {
+        align-self: flex-end;
+        background: linear-gradient(135deg, rgba(59, 130, 246, 0.9), rgba(37, 99, 235, 0.95));
+        color: #f8fafc;
+      }
+
+      .message.assistant {
+        align-self: flex-start;
+        background: rgba(30, 41, 59, 0.85);
+        border: 1px solid rgba(148, 163, 184, 0.2);
+      }
+
+      .search-results {
+        margin-top: 12px;
+        padding-top: 12px;
+        border-top: 1px solid rgba(148, 163, 184, 0.2);
+        font-size: 0.85rem;
+      }
+
+      .search-results p {
+        margin: 0 0 6px;
+        font-weight: 600;
+        color: #38bdf8;
+      }
+
+      .search-results ul {
+        margin: 0;
+        padding-left: 18px;
+        display: grid;
+        gap: 6px;
+      }
+
+      .search-results a {
+        color: #fbbf24;
+        text-decoration: none;
+      }
+
+      .search-results a:hover {
+        text-decoration: underline;
+      }
+
+      form {
+        padding: 20px 24px;
+        border-top: 1px solid rgba(148, 163, 184, 0.16);
+        background: rgba(15, 23, 42, 0.92);
+        display: grid;
+        gap: 12px;
+      }
+
+      textarea {
+        width: 100%;
+        resize: none;
+        min-height: 90px;
+        padding: 14px;
+        border-radius: 12px;
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        background: rgba(15, 23, 42, 0.7);
+        color: inherit;
+        font-size: 1rem;
+        line-height: 1.5;
+      }
+
+      textarea:focus {
+        outline: none;
+        border-color: rgba(59, 130, 246, 0.8);
+        box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.25);
+      }
+
+      button {
+        justify-self: end;
+        padding: 12px 28px;
+        border: none;
+        border-radius: 999px;
+        font-size: 1rem;
+        font-weight: 600;
+        cursor: pointer;
+        background: linear-gradient(135deg, #38bdf8, #6366f1);
+        color: #0f172a;
+        transition: transform 0.2s ease;
+      }
+
+      button[disabled] {
+        cursor: not-allowed;
+        opacity: 0.7;
+        transform: none !important;
+      }
+
+      button:hover {
+        transform: translateY(-1px);
+      }
+
+      .status {
+        font-size: 0.85rem;
+        color: rgba(148, 163, 184, 0.9);
+        text-align: right;
+        min-height: 1em;
+      }
+
+      @media (max-width: 600px) {
+        header {
+          flex-direction: column;
+          align-items: flex-start;
+          gap: 12px;
+        }
+
+        .message {
+          max-width: 100%;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="app">
+      <header>
+        <h1>GPT-4o Chatbot</h1>
+        <div class="mode-select">
+          <span>模式：</span>
+          <label>
+            <input type="radio" name="mode" value="llm_only" checked />
+            純 LLM
+          </label>
+          <label>
+            <input type="radio" name="mode" value="search" />
+            網頁查詢 + LLM
+          </label>
+        </div>
+      </header>
+      <main id="chat-log" aria-live="polite"></main>
+      <form id="chat-form">
+        <textarea
+          id="message-input"
+          placeholder="輸入您的問題或想聊的話題..."
+          required
+        ></textarea>
+        <button type="submit">送出</button>
+        <div class="status" id="status"></div>
+      </form>
+    </div>
+
+    <script>
+      const chatLog = document.getElementById("chat-log");
+      const form = document.getElementById("chat-form");
+      const messageInput = document.getElementById("message-input");
+      const statusEl = document.getElementById("status");
+      let history = [];
+
+      function appendMessage(role, content, searchResults = []) {
+        const wrapper = document.createElement("div");
+        wrapper.className = `message ${role}`;
+        wrapper.textContent = content;
+
+        if (role === "assistant" && searchResults.length) {
+          const resultsBlock = document.createElement("div");
+          resultsBlock.className = "search-results";
+          resultsBlock.innerHTML = `
+            <p>🔎 使用了即時網頁查詢結果：</p>
+            <ul>
+              ${searchResults
+                .map(
+                  (item) => `
+                    <li>
+                      <a href="${item.url}" target="_blank" rel="noopener noreferrer">
+                        ${item.title}
+                      </a>
+                    </li>
+                  `
+                )
+                .join("")}
+            </ul>
+          `;
+          wrapper.appendChild(resultsBlock);
+        }
+
+        chatLog.appendChild(wrapper);
+        chatLog.scrollTop = chatLog.scrollHeight;
+      }
+
+      async function sendMessage(event) {
+        event.preventDefault();
+        const message = messageInput.value.trim();
+        if (!message) {
+          return;
+        }
+
+        const mode = document.querySelector('input[name="mode"]:checked').value;
+        appendMessage("user", message);
+        history.push({ role: "user", content: message });
+        form.querySelector("button").disabled = true;
+        statusEl.textContent = mode === "search" ? "正在搜尋並產生回應..." : "正在產生回應...";
+
+        try {
+          const response = await fetch("/chat", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ message, mode, history }),
+          });
+
+          if (!response.ok) {
+            const error = await response.json().catch(() => ({}));
+            throw new Error(error.detail || "伺服器發生錯誤");
+          }
+
+          const data = await response.json();
+          appendMessage("assistant", data.reply, data.used_search ? data.search_results : []);
+          history.push({ role: "assistant", content: data.reply });
+          statusEl.textContent = "完成";
+        } catch (error) {
+          console.error(error);
+          appendMessage("assistant", `⚠️ ${error.message}`);
+          statusEl.textContent = "錯誤";
+        } finally {
+          form.querySelector("button").disabled = false;
+          messageInput.value = "";
+          messageInput.focus();
+        }
+      }
+
+      form.addEventListener("submit", sendMessage);
+    </script>
+  </body>
+</html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -124,6 +124,15 @@
         text-decoration: underline;
       }
 
+      .search-results li {
+        list-style: disc;
+      }
+
+      .search-results li p {
+        margin: 4px 0 0;
+        color: rgba(226, 232, 240, 0.82);
+      }
+
       form {
         padding: 20px 24px;
         border-top: 1px solid rgba(148, 163, 184, 0.16);
@@ -237,22 +246,30 @@
         if (role === "assistant" && searchResults.length) {
           const resultsBlock = document.createElement("div");
           resultsBlock.className = "search-results";
-          resultsBlock.innerHTML = `
-            <p>🔎 使用了即時網頁查詢結果：</p>
-            <ul>
-              ${searchResults
-                .map(
-                  (item) => `
-                    <li>
-                      <a href="${item.url}" target="_blank" rel="noopener noreferrer">
-                        ${item.title}
-                      </a>
-                    </li>
-                  `
-                )
-                .join("")}
-            </ul>
-          `;
+          const heading = document.createElement("p");
+          heading.textContent = "🔎 使用了即時網頁查詢結果：";
+          const list = document.createElement("ul");
+
+          searchResults.forEach((item) => {
+            const listItem = document.createElement("li");
+            const link = document.createElement("a");
+            link.href = item.url;
+            link.target = "_blank";
+            link.rel = "noopener noreferrer";
+            link.textContent = item.title || item.url;
+            listItem.appendChild(link);
+
+            if (item.snippet) {
+              const snippet = document.createElement("p");
+              snippet.textContent = item.snippet;
+              listItem.appendChild(snippet);
+            }
+
+            list.appendChild(listItem);
+          });
+
+          resultsBlock.appendChild(heading);
+          resultsBlock.appendChild(list);
           wrapper.appendChild(resultsBlock);
         }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -331,11 +331,24 @@
         return DOMPurify.sanitize(html);
       }
 
+      function getAnchorTop() {
+        if (!activeAnchor || !activeAnchor.isConnected) {
+          return null;
+        }
+        const anchorRect = activeAnchor.getBoundingClientRect();
+        const containerRect = chatLog.getBoundingClientRect();
+        return anchorRect.top - containerRect.top + chatLog.scrollTop;
+      }
+
       function scrollToAnchor(smooth = true) {
         if (!activeAnchor || !autoScrollEnabled) {
           return;
         }
-        const top = Math.max(activeAnchor.offsetTop - 12, 0);
+        const anchorTop = getAnchorTop();
+        if (anchorTop === null) {
+          return;
+        }
+        const top = Math.max(anchorTop - 12, 0);
         isProgrammaticScroll = true;
         if (typeof chatLog.scrollTo === "function") {
           chatLog.scrollTo({ top, behavior: smooth ? "smooth" : "auto" });
@@ -378,8 +391,12 @@
         if (!activeAnchor || isProgrammaticScroll) {
           return;
         }
-        const anchorTop = Math.max(activeAnchor.offsetTop - 12, 0);
-        const distance = Math.abs(chatLog.scrollTop - anchorTop);
+        const anchorTop = getAnchorTop();
+        if (anchorTop === null) {
+          return;
+        }
+        const targetTop = Math.max(anchorTop - 12, 0);
+        const distance = Math.abs(chatLog.scrollTop - targetTop);
         if (autoScrollEnabled && distance > 24) {
           autoScrollEnabled = false;
         } else if (!autoScrollEnabled && distance <= 12) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -333,6 +333,9 @@
         return DOMPurify.sanitize(html);
       }
 
+      let anchorMessage = null;
+      let anchorAlignedForReply = false;
+
       function pinMessageToTop(wrapper) {
         requestAnimationFrame(() => {
           if (typeof wrapper.scrollIntoView === "function") {
@@ -345,6 +348,14 @@
             chatLog.scrollTop = targetTop;
           }
         });
+      }
+
+      function alignAnchorForReply() {
+        if (!anchorMessage || anchorAlignedForReply) {
+          return;
+        }
+        pinMessageToTop(anchorMessage);
+        anchorAlignedForReply = true;
       }
 
       function createMessage(role, initialText = "") {
@@ -360,6 +371,8 @@
         wrapper.appendChild(textEl);
         chatLog.appendChild(wrapper);
         if (role === "user") {
+          anchorMessage = wrapper;
+          anchorAlignedForReply = false;
           pinMessageToTop(wrapper);
         }
         return { wrapper, textEl };
@@ -461,6 +474,7 @@
           }
 
           assistantMessage = createMessage("assistant", "");
+          alignAnchorForReply();
 
           const reader = response.body.getReader();
           const decoder = new TextDecoder();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -457,6 +457,14 @@
         search_auto: "正在判斷是否需要搜尋並產生回應...",
       };
 
+      messageInput.addEventListener("keydown", (event) => {
+        if (event.key !== "Enter" || event.shiftKey || event.isComposing) {
+          return;
+        }
+        event.preventDefault();
+        form.requestSubmit();
+      });
+
       function renderMarkdown(markdownText) {
         if (!markdownText) {
           return "";

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -280,8 +280,12 @@
             純 LLM
           </label>
           <label>
-            <input type="radio" name="mode" value="search" />
-            網頁查詢 + LLM
+            <input type="radio" name="mode" value="search_duckduckgo" />
+            網頁查詢（DuckDuckGo） + LLM
+          </label>
+          <label>
+            <input type="radio" name="mode" value="search_serpapi" />
+            網頁查詢（SerpAPI） + LLM
           </label>
         </div>
       </header>
@@ -313,6 +317,11 @@
       let activeAnchor = null;
       let autoScrollEnabled = true;
       let isProgrammaticScroll = false;
+      const modeStatusText = {
+        llm_only: "正在產生回應...",
+        search_duckduckgo: "正在以 DuckDuckGo 搜尋並產生回應...",
+        search_serpapi: "正在以 SerpAPI 搜尋並產生回應...",
+      };
 
       function renderMarkdown(markdownText) {
         if (!markdownText) {
@@ -380,7 +389,7 @@
 
       chatLog.addEventListener("scroll", handleScroll, { passive: true });
 
-      function renderSearchResults(wrapper, searchResults = []) {
+      function renderSearchResults(wrapper, searchResults = [], provider = null) {
         const existing = wrapper.querySelector(".search-results");
         if (existing) {
           existing.remove();
@@ -393,7 +402,13 @@
         const resultsBlock = document.createElement("div");
         resultsBlock.className = "search-results";
         const heading = document.createElement("p");
-        heading.textContent = "🔎 使用了即時網頁查詢結果：";
+        let providerLabel = "即時網頁查詢結果";
+        if (provider === "duckduckgo") {
+          providerLabel = "DuckDuckGo 網頁查詢結果";
+        } else if (provider === "serpapi") {
+          providerLabel = "SerpAPI 網頁查詢結果";
+        }
+        heading.textContent = `🔎 使用了${providerLabel}：`;
         const list = document.createElement("ul");
 
         searchResults.forEach((item) => {
@@ -432,7 +447,7 @@
         history.push({ role: "user", content: message });
         const submitButton = form.querySelector("button");
         submitButton.disabled = true;
-        statusEl.textContent = mode === "search" ? "正在搜尋並產生回應..." : "正在產生回應...";
+        statusEl.textContent = modeStatusText[mode] || "正在產生回應...";
 
         let assistantMessage;
         let finalReply = "";
@@ -503,8 +518,15 @@
               }
 
               if (eventType === "meta") {
-                if (parsed.used_search && Array.isArray(parsed.search_results)) {
-                  pendingSearchResults = parsed.search_results;
+                if (parsed.used_search) {
+                  pendingSearchResults = {
+                    provider: parsed.search_provider || null,
+                    results: Array.isArray(parsed.search_results)
+                      ? parsed.search_results
+                      : [],
+                  };
+                } else {
+                  pendingSearchResults = null;
                 }
               } else if (eventType === "delta") {
                 if (parsed.text) {
@@ -518,8 +540,16 @@
                   assistantMessage.textEl.innerHTML = renderMarkdown(finalReply);
                   scrollToAnchor(false);
                 }
-                if (pendingSearchResults && pendingSearchResults.length) {
-                  renderSearchResults(assistantMessage.wrapper, pendingSearchResults);
+                if (
+                  pendingSearchResults &&
+                  Array.isArray(pendingSearchResults.results) &&
+                  pendingSearchResults.results.length
+                ) {
+                  renderSearchResults(
+                    assistantMessage.wrapper,
+                    pendingSearchResults.results,
+                    pendingSearchResults.provider || null
+                  );
                 }
                 receivedDone = true;
               } else if (eventType === "error") {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -325,13 +325,48 @@
         search_auto: "正在判斷是否需要搜尋並產生回應...",
       };
 
-      function scrollToBottom(smooth = true) {
-        const behavior = smooth ? "smooth" : "auto";
-        if (typeof chatLog.scrollTo === "function") {
-          chatLog.scrollTo({ top: chatLog.scrollHeight, behavior });
+      let anchorMessage = null;
+      let anchorSpacing = 0;
+      let autoScrollEnabled = true;
+      let isProgrammaticScroll = false;
+
+      function scheduleProgrammaticFlagReset() {
+        if (typeof window.requestAnimationFrame === "function") {
+          window.requestAnimationFrame(() => {
+            isProgrammaticScroll = false;
+          });
         } else {
-          chatLog.scrollTop = chatLog.scrollHeight;
+          setTimeout(() => {
+            isProgrammaticScroll = false;
+          }, 16);
         }
+      }
+
+      function performScroll(top, behavior = "auto") {
+        isProgrammaticScroll = true;
+        if (typeof chatLog.scrollTo === "function") {
+          chatLog.scrollTo({ top, behavior });
+        } else {
+          chatLog.scrollTop = top;
+        }
+        scheduleProgrammaticFlagReset();
+      }
+
+      function maintainAnchor({ smooth = false } = {}) {
+        if (!anchorMessage || !autoScrollEnabled) {
+          return;
+        }
+        const targetTop = Math.max(anchorMessage.offsetTop - anchorSpacing, 0);
+        if (Math.abs(chatLog.scrollTop - targetTop) > 1) {
+          performScroll(targetTop, smooth ? "smooth" : "auto");
+        }
+      }
+
+      function setAnchor(element) {
+        anchorMessage = element;
+        anchorSpacing = 0;
+        autoScrollEnabled = true;
+        maintainAnchor();
       }
 
       function renderMarkdown(markdownText) {
@@ -354,7 +389,11 @@
         }
         wrapper.appendChild(textEl);
         chatLog.appendChild(wrapper);
-        scrollToBottom(role === "user");
+        if (role === "user") {
+          setAnchor(wrapper);
+        } else {
+          maintainAnchor();
+        }
         return { wrapper, textEl };
       }
 
@@ -408,8 +447,33 @@
         resultsBlock.appendChild(heading);
         resultsBlock.appendChild(list);
         wrapper.appendChild(resultsBlock);
-        scrollToBottom(false);
+        maintainAnchor();
       }
+
+      chatLog.addEventListener("scroll", () => {
+        if (!anchorMessage || isProgrammaticScroll) {
+          return;
+        }
+
+        const currentSpacing = anchorMessage.offsetTop - chatLog.scrollTop;
+
+        if (!autoScrollEnabled) {
+          anchorSpacing = currentSpacing;
+          if (Math.abs(currentSpacing) <= 4) {
+            autoScrollEnabled = true;
+            maintainAnchor();
+          }
+          return;
+        }
+
+        if (Math.abs(currentSpacing - anchorSpacing) > 6) {
+          autoScrollEnabled = false;
+          anchorSpacing = currentSpacing;
+          return;
+        }
+
+        anchorSpacing = currentSpacing;
+      });
 
       async function sendMessage(event) {
         event.preventDefault();
@@ -517,13 +581,13 @@
                 if (parsed.text) {
                   finalReply += parsed.text;
                   assistantMessage.textEl.innerHTML = renderMarkdown(finalReply);
-                  scrollToBottom(false);
+                  maintainAnchor();
                 }
               } else if (eventType === "done") {
                 if (typeof parsed.text === "string") {
                   finalReply = parsed.text;
                   assistantMessage.textEl.innerHTML = renderMarkdown(finalReply);
-                  scrollToBottom(false);
+                  maintainAnchor();
                 }
                 if (
                   pendingSearchResults &&
@@ -536,6 +600,7 @@
                     pendingSearchResults.provider || null,
                     { autoTriggered: Boolean(pendingSearchResults.autoTriggered) }
                   );
+                  maintainAnchor();
                 }
                 receivedDone = true;
               } else if (eventType === "error") {
@@ -570,7 +635,7 @@
             assistantMessage = createMessage("assistant", "");
           }
           assistantMessage.textEl.textContent = `⚠️ ${error.message}`;
-          scrollToBottom(false);
+          maintainAnchor();
           statusEl.textContent = "錯誤";
         } finally {
           submitButton.disabled = false;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -247,7 +247,7 @@
         background: rgba(15, 23, 42, 0.92);
         display: grid;
         gap: 14px;
-        max-height: min(214px, 30vh);
+        max-height: min(240px, 45vh);
         overflow-y: auto;
       }
 
@@ -411,7 +411,7 @@
       <main id="chat-log" aria-live="polite"></main>
       <form id="chat-form">
         <div class="upload-section">
-          <label for="file-input">附件</label>
+          <label for="file-input">附件(支援 PDF、純文字，作為回答參考)</label>
           <div class="upload-controls">
             <input
               type="file"
@@ -420,7 +420,6 @@
               multiple
             />
           </div>
-          <p class="upload-help">支援 PDF、純文字，作為回答參考。</p>
           <div class="upload-status" id="upload-status"></div>
           <ul class="uploads-list" id="uploads-list"></ul>
         </div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ openai>=1.30.0
 python-multipart>=0.0.9
 ddgs>=1.1.0
 google-search-results>=2.4.2
+pypdf>=4.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests>=2.31.0
 openai>=1.30.0
 python-multipart>=0.0.9
 duckduckgo-search>=6.1.0
+google-search-results>=2.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi>=0.110.0
+uvicorn[standard]>=0.27.0
+requests>=2.31.0
+openai>=1.30.0
+python-multipart>=0.0.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ uvicorn[standard]>=0.27.0
 requests>=2.31.0
 openai>=1.30.0
 python-multipart>=0.0.9
-duckduckgo-search>=5.3.0
+duckduckgo-search>=6.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ uvicorn[standard]>=0.27.0
 requests>=2.31.0
 openai>=1.30.0
 python-multipart>=0.0.9
-duckduckgo-search>=6.1.0
+ddgs>=1.1.0
 google-search-results>=2.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]>=0.27.0
 requests>=2.31.0
 openai>=1.30.0
 python-multipart>=0.0.9
+duckduckgo-search>=5.3.0


### PR DESCRIPTION
## Summary
- build a FastAPI service that proxies chat messages to GPT-4o and optionally enriches prompts with DuckDuckGo search snippets
- add a responsive HTML/JavaScript single-page chat client with LLM-only and search-assisted modes
- document setup steps and dependencies for running the chatbot locally

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68cb669571388324952df4c8206bf7a7